### PR TITLE
Fix component destroy when resource is already deleted externally

### DIFF
--- a/provider/component_resource.go
+++ b/provider/component_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/cycloidio/terraform-provider-cycloid/internal/dynamic"
@@ -90,12 +91,32 @@ func (r *ComponentResource) Read(ctx context.Context, req resource.ReadRequest, 
 			break
 		}
 	}
+	if component == nil {
+		resp.Diagnostics.Append(
+			ComponentToModel(ctx, org, nil, nil, nil, &componentState)...,
+		)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &componentState)...)
+		return
+	}
 
 	var inputVariables map[string]map[string]map[string]any
 	var currentConfig map[string]map[string]map[string]any
 	var diags diag.Diagnostics
 	currentConfig, err = m.GetComponentConfig(org, project, environment, canonical)
 	if err != nil {
+		if isComponentNotFoundError(err) {
+			resp.Diagnostics.Append(
+				ComponentToModel(ctx, org, nil, nil, nil, &componentState)...,
+			)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			resp.Diagnostics.Append(resp.State.Set(ctx, &componentState)...)
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to get component config in org %q, project %q, environment %q", org, project, environment), err.Error())
 		return
 	}
@@ -366,6 +387,16 @@ func (r *ComponentResource) Delete(ctx context.Context, req resource.DeleteReque
 	if component != nil {
 		err = m.DeleteComponent(org, project, environment, canonical)
 		if err != nil {
+			if isComponentNotFoundError(err) {
+				resp.Diagnostics.Append(
+					ComponentToModel(ctx, org, nil, nil, nil, &componentState)...,
+				)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				resp.Diagnostics.Append(resp.State.Set(ctx, &componentState)...)
+				return
+			}
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("failed to delete component %q in org %q, project %q, environment %q", canonical, org, project, environment), err.Error(),
 			)
@@ -552,4 +583,14 @@ func matchStackVersion(versions []*models.ServiceCatalogSourceVersion, stackVers
 	}
 
 	return tag, branch, commit
+}
+
+func isComponentNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "component was not found") ||
+		strings.Contains(errMsg, "getcomponentconfignotfound")
 }

--- a/provider/component_resource_test.go
+++ b/provider/component_resource_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cycloidio/terraform-provider-cycloid/internal/dynamic"
@@ -67,4 +68,39 @@ func TestGetInputVariablesForReadReturnsStateInputsWhenVariableUpdatesEnabled(t 
 	}
 
 	assert.Equal(t, stateInputVariables, output, "Read must preserve user-provided input_variables from state")
+}
+
+func TestIsComponentNotFoundError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "component config not found operation",
+			err:      errors.New("A 404 error was returned on \"getComponentConfigNotFound\" call with message: The Component was not found"),
+			expected: true,
+		},
+		{
+			name:     "component not found message",
+			err:      errors.New("The Component was not found"),
+			expected: true,
+		},
+		{
+			name:     "different not found message",
+			err:      errors.New("A 404 error was returned on \"getProjectNotFound\" call"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, isComponentNotFoundError(testCase.err))
+		})
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix `cycloid_component` read flow to clear Terraform state when the component no longer exists instead of attempting `GetComponentConfig`
- add tolerant handling for component-not-found API responses during config fetch and delete race conditions
- add unit tests for component not-found error detection used by read/delete flows

## Why
Destroy should be idempotent when the component has already been removed outside Terraform. Previously the provider could fail during refresh/destroy with:
`getComponentConfigNotFound` / `The Component was not found`.

## Validation
- `go test ./provider -run 'Test(DynamicValueToVariablesPreservesAllGroupKeys|GetInputVariablesForReadReturnsStateInputsWhenVariableUpdatesEnabled|IsComponentNotFoundError)$' -v`
- `go test ./... -count=1`
- `make build`

## Scope check for similar resources
- reviewed similar list-based resources (`project`, `environment`, `team`) and they already clear state when the remote object is absent
- issue pattern was specific to `component` read continuing into config fetch after missing detection
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-25](https://linear.app/cycloid/issue/TFPRO-25/component-resource-report-error-when-component-is-deleted-outside-of)

<div><a href="https://cursor.com/agents/bc-a9d72835-17f6-4183-b35f-e82bf74073f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9d72835-17f6-4183-b35f-e82bf74073f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

