### PR TITLE
Fix catalog_repository owner state and assignment handling

### DIFF
--- a/provider/catalog_repository_resource.go
+++ b/provider/catalog_repository_resource.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/cycloidio/cycloid-cli/client/client/organization_service_catalog_sources"
 	"github.com/cycloidio/cycloid-cli/client/models"
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/resource_catalog_repository"
+	strfmt "github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -16,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/pkg/errors"
 )
 
 var _ resource.Resource = (*catalogRepositoryResource)(nil)
@@ -76,13 +80,16 @@ func (r *catalogRepositoryResource) Configure(ctx context.Context, req resource.
 func (r *catalogRepositoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data catalogRepositoryResourceModel
 
-	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	mid := r.provider.Middleware
+	var configData catalogRepositoryResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	orgCan := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
 	name := data.Name.ValueString()
@@ -91,9 +98,17 @@ func (r *catalogRepositoryResource) Create(ctx context.Context, req resource.Cre
 	credCan := data.CredentialCanonical.ValueString()
 	visibility := data.OnCreateVisibility.ValueString()
 	team := data.OnCreateTeam.ValueString()
+	owner, ownerConfigured := configuredCatalogRepositoryOwner(configData.Owner)
 
-	cr, err := mid.CreateCatalogRepository(orgCan, name, url, branch, credCan, visibility, team)
+	cr, err := r.createCatalogRepository(orgCan, name, url, branch, credCan, visibility, team, owner)
 	if err != nil {
+		if ownerConfigured {
+			resp.Diagnostics.AddError(
+				"Unable create catalog repository with requested owner",
+				fmt.Sprintf("Unable to assign owner %q to catalog repository %q in organization %q: %s. A common cause is that this user is not invited in the target organization.", owner, name, orgCan, err.Error()),
+			)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable create catalog repository",
 			err.Error(),
@@ -140,26 +155,27 @@ func (r *catalogRepositoryResource) Read(ctx context.Context, req resource.ReadR
 func (r *catalogRepositoryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data catalogRepositoryResourceModel
 
-	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Update API call logic
-	mid := r.provider.Middleware
+	var configData catalogRepositoryResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	orgCan := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
 	name := data.Name.ValueString()
 	url := data.Url.ValueString()
 	branch := data.Branch.ValueString()
 	credCan := data.CredentialCanonical.ValueString()
+	owner, ownerConfigured := configuredCatalogRepositoryOwner(configData.Owner)
 	can := data.Canonical.ValueString()
 
 	if can == "" {
 		var plandata catalogRepositoryResourceModel
-		// Read Terraform prior state data into the model
 		resp.Diagnostics.Append(req.State.Get(ctx, &plandata)...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -167,8 +183,15 @@ func (r *catalogRepositoryResource) Update(ctx context.Context, req resource.Upd
 		can = plandata.Canonical.ValueString()
 	}
 
-	cr, err := mid.UpdateCatalogRepository(orgCan, can, name, url, branch, credCan)
+	cr, err := r.updateCatalogRepository(orgCan, can, name, url, branch, credCan, owner)
 	if err != nil {
+		if ownerConfigured {
+			resp.Diagnostics.AddError(
+				"Unable update catalog repository with requested owner",
+				fmt.Sprintf("Unable to assign owner %q to catalog repository %q in organization %q: %s. A common cause is that this user is not invited in the target organization.", owner, can, orgCan, err.Error()),
+			)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable update catalog repository",
 			err.Error(),
@@ -212,8 +235,15 @@ func catalogRepositoryCYModelToData(org string, cr *models.ServiceCatalogSource,
 	var diags diag.Diagnostics
 	ctx := context.Background()
 
-	if cr.Owner != nil {
+	if cr.Owner != nil && cr.Owner.Username != nil {
 		data.Owner = types.StringPointerValue(cr.Owner.Username)
+	} else {
+		data.Owner = types.StringValue("")
+	}
+
+	stackCount := int64(0)
+	if cr.StackCount != nil {
+		stackCount = int64(*cr.StackCount)
 	}
 
 	data.Name = types.StringPointerValue(cr.Name)
@@ -222,9 +252,6 @@ func catalogRepositoryCYModelToData(org string, cr *models.ServiceCatalogSource,
 	data.Canonical = types.StringPointerValue(cr.Canonical)
 	data.OrganizationCanonical = types.StringValue(org)
 	data.CredentialCanonical = types.StringValue(cr.CredentialCanonical)
-	if cr.Owner != nil {
-		data.Owner = types.StringValue(*cr.Owner.Username)
-	}
 
 	stacksValue, diagErr := crStacksToListValue(ctx, cr.ServiceCatalogs)
 	diags.Append(diagErr...)
@@ -242,18 +269,98 @@ func catalogRepositoryCYModelToData(org string, cr *models.ServiceCatalogSource,
 			"url": basetypes.StringType{},
 		},
 		map[string]attr.Value{
-			"name":                 types.StringValue(*cr.Canonical),
+			"name":                 types.StringPointerValue(cr.Name),
 			"branch":               types.StringValue(cr.Branch),
-			"canonical":            types.StringValue(*cr.Canonical),
-			"credential_canonical": types.StringValue(*cr.Canonical),
-			"stack_count":          types.Int64Value(int64(*cr.StackCount)),
-			"url":                  types.StringValue(*cr.URL),
+			"canonical":            types.StringPointerValue(cr.Canonical),
+			"credential_canonical": types.StringValue(cr.CredentialCanonical),
+			"stack_count":          types.Int64Value(stackCount),
+			"url":                  types.StringPointerValue(cr.URL),
 			"stacks":               stacksValue,
 		})
 	diags.Append(diagErr...)
 	data.Data = dataValue
 
 	return diags
+}
+
+func configuredCatalogRepositoryOwner(owner types.String) (string, bool) {
+	if owner.IsNull() || owner.IsUnknown() {
+		return "", false
+	}
+
+	ownerValue := owner.ValueString()
+	if ownerValue == "" {
+		return "", false
+	}
+
+	return ownerValue, true
+}
+
+func (r *catalogRepositoryResource) createCatalogRepository(org, name, url, branch, cred, visibility, teamCanonical, owner string) (*models.ServiceCatalogSource, error) {
+	params := organization_service_catalog_sources.NewCreateServiceCatalogSourceParams()
+	params.SetOrganizationCanonical(org)
+
+	body := &models.NewServiceCatalogSource{
+		Branch: &branch,
+		Name:   &name,
+		URL:    &url,
+	}
+	if cred != "" {
+		body.CredentialCanonical = cred
+	}
+	if owner != "" {
+		body.Owner = owner
+	}
+	switch visibility {
+	case "shared", "local", "hidden":
+		body.Visibility = visibility
+	case "":
+	default:
+		return nil, errors.New("invalid visibility parameter for CreateCatalogRepository, accepted values are 'local', 'shared' or 'hidden'")
+	}
+	if teamCanonical != "" {
+		body.TeamCanonical = teamCanonical
+	}
+
+	params.SetBody(body)
+	if err := body.Validate(strfmt.Default); err != nil {
+		return nil, err
+	}
+
+	resp, err := r.provider.APIClient.OrganizationServiceCatalogSources.CreateServiceCatalogSource(params, r.provider.APIClient.Credentials(&org))
+	if err != nil {
+		return nil, cycloidmiddleware.NewAPIError(err)
+	}
+
+	return resp.GetPayload().Data, nil
+}
+
+func (r *catalogRepositoryResource) updateCatalogRepository(org, catalogRepo, name, url, branch, cred, owner string) (*models.ServiceCatalogSource, error) {
+	params := organization_service_catalog_sources.NewUpdateServiceCatalogSourceParams()
+	params.SetOrganizationCanonical(org)
+	params.SetServiceCatalogSourceCanonical(catalogRepo)
+
+	body := &models.UpdateServiceCatalogSource{
+		Branch:              branch,
+		CredentialCanonical: cred,
+		Name:                &name,
+		URL:                 &url,
+	}
+	if owner != "" {
+		body.Owner = owner
+	}
+
+	params.SetBody(body)
+	if err := body.Validate(strfmt.Default); err != nil {
+		return nil, err
+	}
+
+	resp, err := r.provider.APIClient.OrganizationServiceCatalogSources.UpdateServiceCatalogSource(params, r.provider.APIClient.Credentials(&org))
+	if err != nil {
+		return nil, cycloidmiddleware.NewAPIError(err)
+	}
+
+	return resp.GetPayload().Data, nil
 }
 
 func crStacksToListValue(ctx context.Context, stacks []*models.ServiceCatalog) (basetypes.ListValue, diag.Diagnostics) {

--- a/provider/catalog_repository_resource_test.go
+++ b/provider/catalog_repository_resource_test.go
@@ -16,8 +16,9 @@ func p[T any](val T) *T {
 
 func TestCyModelToData(t *testing.T) {
 	testCases := []struct {
-		Model *models.ServiceCatalogSource
-		Data  *catalogRepositoryResourceModel
+		Model         *models.ServiceCatalogSource
+		Data          *catalogRepositoryResourceModel
+		ExpectedOwner string
 	}{
 		{
 			Model: &models.ServiceCatalogSource{
@@ -45,6 +46,32 @@ func TestCyModelToData(t *testing.T) {
 				Owner:                 types.StringValue(""),
 				Url:                   types.StringValue(""),
 			},
+			ExpectedOwner: "owner",
+		},
+		{
+			Model: &models.ServiceCatalogSource{
+				Branch:              "branch",
+				Canonical:           p("stack-canonical"),
+				CredentialCanonical: "cred-canonical",
+				ServiceCatalogs: []*models.ServiceCatalog{{
+					Canonical: p("stack-canonical"),
+				}},
+				Owner:      nil,
+				URL:        p("osef"),
+				Name:       p("stack-name"),
+				StackCount: p(uint32(1)),
+				ID:         p(uint32(1)),
+			},
+			Data: &catalogRepositoryResourceModel{
+				Branch:                types.StringValue(""),
+				Canonical:             types.StringValue(""),
+				CredentialCanonical:   types.StringValue(""),
+				Name:                  types.StringValue(""),
+				OrganizationCanonical: types.StringValue(""),
+				Owner:                 types.StringUnknown(),
+				Url:                   types.StringValue(""),
+			},
+			ExpectedOwner: "",
 		},
 	}
 
@@ -59,7 +86,49 @@ func TestCyModelToData(t *testing.T) {
 		assert.Equal(t, *testCase.Model.Canonical, testCase.Data.Canonical.ValueString(), "canonical must be equal")
 		assert.Equal(t, testCase.Model.CredentialCanonical, testCase.Data.CredentialCanonical.ValueString(), "credentialcanonical must be equal")
 		assert.Equal(t, *testCase.Model.Name, testCase.Data.Name.ValueString(), "name must be equal")
-		assert.Equal(t, *testCase.Model.Owner.Username, testCase.Data.Owner.ValueString(), "owner must be equal")
+		assert.Equal(t, testCase.ExpectedOwner, testCase.Data.Owner.ValueString(), "owner must be equal")
 		assert.Equal(t, *testCase.Model.URL, testCase.Data.Url.ValueString(), "url must be equal")
+	}
+}
+
+func TestConfiguredCatalogRepositoryOwner(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Owner         types.String
+		ExpectedValue string
+		ExpectedSet   bool
+	}{
+		{
+			Name:          "known owner",
+			Owner:         types.StringValue("alice"),
+			ExpectedValue: "alice",
+			ExpectedSet:   true,
+		},
+		{
+			Name:          "empty owner",
+			Owner:         types.StringValue(""),
+			ExpectedValue: "",
+			ExpectedSet:   false,
+		},
+		{
+			Name:          "null owner",
+			Owner:         types.StringNull(),
+			ExpectedValue: "",
+			ExpectedSet:   false,
+		},
+		{
+			Name:          "unknown owner",
+			Owner:         types.StringUnknown(),
+			ExpectedValue: "",
+			ExpectedSet:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			owner, set := configuredCatalogRepositoryOwner(testCase.Owner)
+			assert.Equal(t, testCase.ExpectedValue, owner)
+			assert.Equal(t, testCase.ExpectedSet, set)
+		})
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fixed `cycloid_catalog_repository` apply behavior so `owner` is always written as a known value in state (empty string when backend returns no owner)
- added explicit create/update API calls for catalog repositories that include `owner` when it is explicitly configured by the user
- added clearer diagnostics when owner assignment fails, including a likely cause when the requested owner is not invited in the target organization
- hardened catalog repository model mapping to avoid nil dereferences in owner/stack count fields

## Testing
- `go test ./provider -run "TestCyModelToData|TestConfiguredCatalogRepositoryOwner" -v`
- `go test ./provider -v`
- `make build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-27](https://linear.app/cycloid/issue/TFPRO-27/catalog-repository-resource)

<div><a href="https://cursor.com/agents/bc-9aa06d2a-86f5-4d34-a047-37c494d5b75f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa06d2a-86f5-4d34-a047-37c494d5b75f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

