### PR TITLE
Fix credential canonical retrieval during update

### DIFF
--- a/provider/credential_resource.go
+++ b/provider/credential_resource.go
@@ -153,9 +153,15 @@ func (r *credentialResource) Read(ctx context.Context, req resource.ReadRequest,
 
 func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data credentialResourceModel
+	var stateData credentialResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -181,21 +187,9 @@ func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	path := data.Path.ValueString()
-	canonical := data.Canonical.ValueString()
+	updateCanonical := credentialCanonicalForUpdate(data.Canonical.ValueString(), stateData.Canonical.ValueString())
+	createCanonical := credentialCanonicalForCreate(data.Canonical.ValueString(), stateData.Canonical.ValueString())
 	description := data.Description.ValueString()
-
-	// As the canonical is not required to be set we read it from the
-	// state as we set it on creation and we need it to update the
-	// credential to the API
-	if canonical == "" {
-		var plandata credentialResourceModel
-		// Read Terraform prior state data into the model
-		resp.Diagnostics.Append(req.State.Get(ctx, &plandata)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		canonical = plandata.Canonical.ValueString()
-	}
 
 	organization := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
 
@@ -208,10 +202,12 @@ func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	var credential *models.Credential
-	if slices.IndexFunc(credentials, func(c *models.CredentialSimple) bool { return *c.Canonical == canonical }) == -1 {
-		credential, _, err = m.CreateCredential(organization, name, credentialType, rawCred, path, canonical, description)
+	if slices.IndexFunc(credentials, func(c *models.CredentialSimple) bool {
+		return c.Canonical != nil && *c.Canonical == updateCanonical
+	}) == -1 {
+		credential, _, err = m.CreateCredential(organization, name, credentialType, rawCred, path, createCanonical, description)
 	} else {
-		credential, _, err = m.UpdateCredential(organization, name, credentialType, rawCred, path, canonical, description)
+		credential, _, err = m.UpdateCredential(organization, name, credentialType, rawCred, path, updateCanonical, description)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to update credential", err.Error())
@@ -399,4 +395,12 @@ func dataRawToCredentialRawCYModel(ctx context.Context, data credentialResourceM
 	}
 
 	return rawCred, nil
+}
+
+func credentialCanonicalForUpdate(planCanonical, stateCanonical string) string {
+	return Coalesce(stateCanonical, planCanonical)
+}
+
+func credentialCanonicalForCreate(planCanonical, stateCanonical string) string {
+	return Coalesce(planCanonical, stateCanonical)
 }

--- a/provider/credential_resource_test.go
+++ b/provider/credential_resource_test.go
@@ -578,3 +578,93 @@ func TestCredentialRawCYModelToDataBodyForNonCustomCredential(t *testing.T) {
 	assert.Equal(t, "access_key_value", data.Body.AccessKey.ValueString())
 	assert.True(t, data.Body.Raw.IsNull(), "body.raw should be null for non-custom credentials")
 }
+
+func TestCredentialCanonicalForUpdate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		planCanonical  string
+		stateCanonical string
+		expected       string
+	}{
+		{
+			name:           "uses state canonical when both are set",
+			planCanonical:  "plan-canonical",
+			stateCanonical: "state-canonical",
+			expected:       "state-canonical",
+		},
+		{
+			name:           "uses state canonical when plan is empty",
+			planCanonical:  "",
+			stateCanonical: "state-canonical",
+			expected:       "state-canonical",
+		},
+		{
+			name:           "uses plan canonical when state is empty",
+			planCanonical:  "plan-canonical",
+			stateCanonical: "",
+			expected:       "plan-canonical",
+		},
+		{
+			name:           "returns empty when both are empty",
+			planCanonical:  "",
+			stateCanonical: "",
+			expected:       "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := credentialCanonicalForUpdate(testCase.planCanonical, testCase.stateCanonical)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestCredentialCanonicalForCreate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		planCanonical  string
+		stateCanonical string
+		expected       string
+	}{
+		{
+			name:           "uses plan canonical when both are set",
+			planCanonical:  "plan-canonical",
+			stateCanonical: "state-canonical",
+			expected:       "plan-canonical",
+		},
+		{
+			name:           "uses state canonical when plan is empty",
+			planCanonical:  "",
+			stateCanonical: "state-canonical",
+			expected:       "state-canonical",
+		},
+		{
+			name:           "uses plan canonical when state is empty",
+			planCanonical:  "plan-canonical",
+			stateCanonical: "",
+			expected:       "plan-canonical",
+		},
+		{
+			name:           "returns empty when both are empty",
+			planCanonical:  "",
+			stateCanonical: "",
+			expected:       "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := credentialCanonicalForCreate(testCase.planCanonical, testCase.stateCanonical)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix credential update canonical resolution by preferring the canonical from Terraform state when deciding whether to update an existing credential
- keep recreation behavior aligned with user intent by preferring plan canonical only for the create path when the credential was deleted outside Terraform
- harden credential existence checks by guarding against nil canonical values returned by the API
- add unit tests for canonical selection behavior during update/create resolution

## Testing
- `go test ./provider -run "TestCredentialCanonical|TestCredentialRawCYModelToDataBody" -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-4](https://linear.app/cycloid/issue/TFPRO-4/fix-canonical-retrieval-in-update)

<div><a href="https://cursor.com/agents/bc-21089c4a-ccb3-4558-bcc9-6e00a978043e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21089c4a-ccb3-4558-bcc9-6e00a978043e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

