### PR TITLE
Handle not-found resource reads by removing Terraform state

### DIFF
--- a/provider/catalog_repository_resource.go
+++ b/provider/catalog_repository_resource.go
@@ -137,6 +137,10 @@ func (r *catalogRepositoryResource) Read(ctx context.Context, req resource.ReadR
 
 	cr, _, err := mid.GetCatalogRepository(orgCan, can)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable read catalog repository",
 			err.Error(),

--- a/provider/config_repository_resource.go
+++ b/provider/config_repository_resource.go
@@ -104,6 +104,10 @@ func (r *configRepositoryResource) Read(ctx context.Context, req resource.ReadRe
 
 	cr, _, err := mid.GetConfigRepository(orgCan, can)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable read config repository",
 			err.Error(),

--- a/provider/external_backend_resource.go
+++ b/provider/external_backend_resource.go
@@ -230,6 +230,10 @@ func (r *externalBackendResource) Read(ctx context.Context, req resource.ReadReq
 
 	eb, _, err := mid.GetExternalBackend(orgCan, uint32(id))
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable read external backend",
 			err.Error(),

--- a/provider/not_found.go
+++ b/provider/not_found.go
@@ -1,0 +1,14 @@
+package provider
+
+import "strings"
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errMessage := strings.ToLower(err.Error())
+	return strings.Contains(errMessage, " not found") ||
+		strings.Contains(errMessage, "notfound") ||
+		(strings.Contains(errMessage, "404") && strings.Contains(errMessage, "returned"))
+}

--- a/provider/not_found_test.go
+++ b/provider/not_found_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "external backend 404 error",
+			err:      errors.New("A 404 error was returned on \"getExternalBackend\" call with message: The External Backend was not found"),
+			expected: true,
+		},
+		{
+			name:     "catalog repository 404 error",
+			err:      errors.New("A 404 error was returned on \"getServiceCatalogSource\" call with message: The Service Catalog Source was not found"),
+			expected: true,
+		},
+		{
+			name:     "config repository 404 error",
+			err:      errors.New("A 404 error was returned on \"getConfigRepository\" call with message: The Config Repository was not found"),
+			expected: true,
+		},
+		{
+			name:     "generic notfound operation",
+			err:      errors.New("A 404 error was returned on \"getRoleNotFound\" call"),
+			expected: true,
+		},
+		{
+			name:     "non not found error",
+			err:      errors.New("A 500 error was returned on \"getConfigRepository\" call"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, isNotFoundError(testCase.err))
+		})
+	}
+}

--- a/provider/organization_member_resource.go
+++ b/provider/organization_member_resource.go
@@ -113,6 +113,10 @@ func (r *organizationMemberResource) Read(ctx context.Context, req resource.Read
 
 	m, _, err := mid.GetMember(orgCan, uint32(memberID.ValueInt64()))
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable read member",
 			err.Error(),

--- a/provider/organization_resource.go
+++ b/provider/organization_resource.go
@@ -254,6 +254,10 @@ func (r *organizationResource) Read(ctx context.Context, req resource.ReadReques
 
 	orgs, _, err := m.ListOrganizationChildrens(Coalesce(orgState.ParentOrganization.ValueString(), canonical))
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to read org %q from API", canonical), err.Error())
 		return
 	}
@@ -267,7 +271,7 @@ func (r *organizationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	if org == nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Organization %q not found", canonical), "")
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/provider/organization_role_resource.go
+++ b/provider/organization_role_resource.go
@@ -134,6 +134,10 @@ func (r *organizationRoleResource) Read(ctx context.Context, req resource.ReadRe
 
 	role, _, err := m.GetRole(org, canonical)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to read role %q in org %q", canonical, org), err.Error())
 		return
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared `isNotFoundError` helper to normalize Cycloid API 404/not-found detection
- update resource `Read()` behavior to remove state (instead of returning a hard error) when the remote object no longer exists for:
  - `cycloid_external_backend`
  - `cycloid_catalog_repository`
  - `cycloid_config_repository`
  - `cycloid_organization_member`
  - `cycloid_organization_role`
  - `cycloid_organization`
- add unit tests for not-found error detection using real API error messages from TFPRO-3

## Why
When resources are deleted outside Terraform, provider reads were returning diagnostics, which blocked refresh/plan and prevented Terraform from proposing recreation.

## Validation
- `go test ./provider -run 'Test(IsNotFoundError|IsComponentNotFoundError)' -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-3](https://linear.app/cycloid/issue/TFPRO-3/terraform-provider-unable-to-recreate-deleted-resources)

<div><a href="https://cursor.com/agents/bc-8120c48f-6aa9-4245-b3c7-2e68570db027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8120c48f-6aa9-4245-b3c7-2e68570db027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

