### PR TITLE
Fix credential owner handling on create/update

### DIFF
--- a/provider/credential_resource.go
+++ b/provider/credential_resource.go
@@ -3,10 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/resource_credential"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -53,6 +55,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 
 func (r *credentialResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data credentialResourceModel
+	var configData credentialResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -60,7 +63,10 @@ func (r *credentialResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	m := r.provider.Middleware
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	name := data.Name.ValueString()
 	credentialType := data.Type.ValueString()
@@ -84,8 +90,9 @@ func (r *credentialResource) Create(ctx context.Context, req resource.CreateRequ
 	canonical := data.Canonical.ValueString()
 	description := data.Description.ValueString()
 	organization := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
+	owner, _ := configuredCredentialOwner(configData.Owner)
 
-	cred, _, err := m.CreateCredential(organization, name, credentialType, rawCred, path, canonical, description)
+	cred, _, err := r.createCredential(organization, name, credentialType, rawCred, path, canonical, description, owner)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create credential",
@@ -153,10 +160,16 @@ func (r *credentialResource) Read(ctx context.Context, req resource.ReadRequest,
 
 func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data credentialResourceModel
+	var configData credentialResourceModel
 	var stateData credentialResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configData)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -192,6 +205,7 @@ func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequ
 	description := data.Description.ValueString()
 
 	organization := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
+	owner := resolveCredentialUpdateOwner(configData.Owner, stateData.Owner)
 
 	// we need to check first if the cred exists, it could be deleted outside terraform
 	// in that case, we'll just re-create it
@@ -205,9 +219,9 @@ func (r *credentialResource) Update(ctx context.Context, req resource.UpdateRequ
 	if slices.IndexFunc(credentials, func(c *models.CredentialSimple) bool {
 		return c.Canonical != nil && *c.Canonical == updateCanonical
 	}) == -1 {
-		credential, _, err = m.CreateCredential(organization, name, credentialType, rawCred, path, createCanonical, description)
+		credential, _, err = r.createCredential(organization, name, credentialType, rawCred, path, createCanonical, description, owner)
 	} else {
-		credential, _, err = m.UpdateCredential(organization, name, credentialType, rawCred, path, updateCanonical, description)
+		credential, _, err = r.updateCredential(organization, name, credentialType, rawCred, path, updateCanonical, description, owner)
 	}
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to update credential", err.Error())
@@ -254,7 +268,7 @@ func (r *credentialResource) Delete(ctx context.Context, req resource.DeleteRequ
 func credentialCYModelToData(ctx context.Context, org string, credential *models.Credential, data *credentialResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if credential.Owner != nil {
+	if credential.Owner != nil && credential.Owner.Username != nil {
 		data.Owner = types.StringPointerValue(credential.Owner.Username)
 	} else {
 		data.Owner = types.StringValue("")
@@ -403,4 +417,78 @@ func credentialCanonicalForUpdate(planCanonical, stateCanonical string) string {
 
 func credentialCanonicalForCreate(planCanonical, stateCanonical string) string {
 	return Coalesce(planCanonical, stateCanonical)
+}
+
+func configuredCredentialOwner(owner types.String) (string, bool) {
+	if owner.IsNull() || owner.IsUnknown() {
+		return "", false
+	}
+
+	ownerValue := owner.ValueString()
+	if ownerValue == "" {
+		return "", false
+	}
+
+	return ownerValue, true
+}
+
+func resolveCredentialUpdateOwner(configOwner, stateOwner types.String) string {
+	if owner, configured := configuredCredentialOwner(configOwner); configured {
+		return owner
+	}
+
+	owner, _ := configuredCredentialOwner(stateOwner)
+	return owner
+}
+
+func (r *credentialResource) createCredential(org, name, credentialType string, rawCred *models.CredentialRaw, path, canonical, description, owner string) (*models.Credential, *http.Response, error) {
+	body := &models.NewCredential{
+		Description: description,
+		Name:        &name,
+		Path:        &path,
+		Raw:         rawCred,
+		Type:        &credentialType,
+		Canonical:   canonical,
+	}
+	if owner != "" {
+		body.Owner = owner
+	}
+
+	var result *models.Credential
+	resp, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       "POST",
+		Organization: &org,
+		Route:        []string{"organizations", org, "credentials"},
+		Body:         body,
+	}, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+	return result, resp, nil
+}
+
+func (r *credentialResource) updateCredential(org, name, credentialType string, rawCred *models.CredentialRaw, path, canonical, description, owner string) (*models.Credential, *http.Response, error) {
+	body := &models.UpdateCredential{
+		Description: description,
+		Name:        &name,
+		Path:        &path,
+		Raw:         rawCred,
+		Type:        &credentialType,
+		Canonical:   &canonical,
+	}
+	if owner != "" {
+		body.Owner = owner
+	}
+
+	var result *models.Credential
+	resp, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       "PUT",
+		Organization: &org,
+		Route:        []string{"organizations", org, "credentials", canonical},
+		Body:         body,
+	}, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+	return result, resp, nil
 }

--- a/provider/credential_resource_test.go
+++ b/provider/credential_resource_test.go
@@ -668,3 +668,80 @@ func TestCredentialCanonicalForCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestConfiguredCredentialOwner(t *testing.T) {
+	testCases := []struct {
+		name          string
+		owner         types.String
+		expectedOwner string
+		expectedSet   bool
+	}{
+		{
+			name:          "known owner",
+			owner:         types.StringValue("alice"),
+			expectedOwner: "alice",
+			expectedSet:   true,
+		},
+		{
+			name:          "empty owner",
+			owner:         types.StringValue(""),
+			expectedOwner: "",
+			expectedSet:   false,
+		},
+		{
+			name:          "null owner",
+			owner:         types.StringNull(),
+			expectedOwner: "",
+			expectedSet:   false,
+		},
+		{
+			name:          "unknown owner",
+			owner:         types.StringUnknown(),
+			expectedOwner: "",
+			expectedSet:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			owner, set := configuredCredentialOwner(testCase.owner)
+			assert.Equal(t, testCase.expectedOwner, owner)
+			assert.Equal(t, testCase.expectedSet, set)
+		})
+	}
+}
+
+func TestResolveCredentialUpdateOwner(t *testing.T) {
+	testCases := []struct {
+		name        string
+		configOwner types.String
+		stateOwner  types.String
+		expected    string
+	}{
+		{
+			name:        "config owner takes precedence",
+			configOwner: types.StringValue("configured-owner"),
+			stateOwner:  types.StringValue("state-owner"),
+			expected:    "configured-owner",
+		},
+		{
+			name:        "state owner used when config owner missing",
+			configOwner: types.StringNull(),
+			stateOwner:  types.StringValue("state-owner"),
+			expected:    "state-owner",
+		},
+		{
+			name:        "empty when neither owner exists",
+			configOwner: types.StringUnknown(),
+			stateOwner:  types.StringNull(),
+			expected:    "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			owner := resolveCredentialUpdateOwner(testCase.configOwner, testCase.stateOwner)
+			assert.Equal(t, testCase.expected, owner)
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- honor `owner` from resource config when creating or updating a `cycloid_credential`
- on update, fall back to the current state owner when `owner` is not configured so updates preserve ownership semantics
- guard owner mapping from API responses against nil `username` pointers
- add unit tests for owner extraction and update owner resolution helpers

## Testing
- `go test ./provider -run 'TestConfiguredCredentialOwner|TestResolveCredentialUpdateOwner|TestCredentialRawCYModelToDataBody' -v`
- `TF_ACC=1 go test ./provider -run TestAccCredentialResource_AWS -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-2](https://linear.app/cycloid/issue/TFPRO-2/fs2366-credential-update-fails-with-422-error-on-owner-field)

<div><a href="https://cursor.com/agents/bc-c6e71322-428f-4b71-9f94-1ce9bf0befdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e71322-428f-4b71-9f94-1ce9bf0befdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

