### PR TITLE
fix(credential): retry deletion on 409 Conflict (TFPRO-28)

### DIFF
--- a/provider/credential_resource.go
+++ b/provider/credential_resource.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
 	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var _ resource.Resource = (*credentialResource)(nil)
@@ -251,16 +253,28 @@ func (r *credentialResource) Delete(ctx context.Context, req resource.DeleteRequ
 	canonical := data.Canonical.ValueString()
 	organization := getOrganizationCanonical(*r.provider, data.OrganizationCanonical)
 
-	// Delete API call logic
 	m := r.provider.Middleware
 
-	_, err := m.DeleteCredential(organization, canonical)
+	const maxRetries = 5
+	var err error
+	for attempt := range maxRetries {
+		_, err = m.DeleteCredential(organization, canonical)
+		if err == nil {
+			return
+		}
+		if !isCredentialInUseError(err) {
+			break
+		}
+		delay := time.Duration(attempt+1) * 3 * time.Second
+		tflog.Warn(ctx, fmt.Sprintf(
+			"credential %q is still referenced by a resource (attempt %d/%d); retrying in %s",
+			canonical, attempt+1, maxRetries, delay,
+		))
+		time.Sleep(delay)
+	}
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to delete credential",
-			err.Error(),
-		)
-		return
+		resp.Diagnostics.AddError("Unable to delete credential", err.Error())
 	}
 }
 

--- a/provider/not_found.go
+++ b/provider/not_found.go
@@ -1,6 +1,12 @@
 package provider
 
-import "strings"
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+)
 
 func isNotFoundError(err error) bool {
 	if err == nil {
@@ -11,4 +17,19 @@ func isNotFoundError(err error) bool {
 	return strings.Contains(errMessage, " not found") ||
 		strings.Contains(errMessage, "notfound") ||
 		(strings.Contains(errMessage, "404") && strings.Contains(errMessage, "returned"))
+}
+
+// isCredentialInUseError returns true when the Cycloid API refuses a credential
+// deletion because the credential is still referenced by another resource
+// (e.g. a config repository that was just deleted but whose deletion has not
+// yet propagated). A 409 Conflict status is used as the canonical signal.
+func isCredentialInUseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *cycloidmiddleware.APIResponseError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusConflict
+	}
+	return false
 }

--- a/provider/not_found_test.go
+++ b/provider/not_found_test.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,6 +50,46 @@ func TestIsNotFoundError(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			assert.Equal(t, testCase.expected, isNotFoundError(testCase.err))
+		})
+	}
+}
+
+func TestIsCredentialInUseError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "409 conflict API error",
+			err:      &cycloidmiddleware.APIResponseError{StatusCode: http.StatusConflict},
+			expected: true,
+		},
+		{
+			name:     "422 unprocessable API error",
+			err:      &cycloidmiddleware.APIResponseError{StatusCode: http.StatusUnprocessableEntity},
+			expected: false,
+		},
+		{
+			name:     "404 not found API error",
+			err:      &cycloidmiddleware.APIResponseError{StatusCode: http.StatusNotFound},
+			expected: false,
+		},
+		{
+			name:     "plain error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, isCredentialInUseError(testCase.err))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- When a config repository referencing a credential is deleted, the Cycloid API briefly returns HTTP 409 Conflict on subsequent credential deletion — this PR adds a retry loop to handle that race condition.
- `isCredentialInUseError` added to `not_found.go`: typed `errors.As` check on `*cycloidmiddleware.APIResponseError{StatusCode: 409}` — no fragile string matching.
- `Delete()` in `credential_resource.go` retries up to 5 times with linear 3 s back-off; all other errors break immediately.

## Test plan

- [ ] `TestIsCredentialInUseError` (5 cases) passes — verified locally
- [ ] `TestIsNotFoundError` still passes — verified locally
- [ ] Acceptance: delete a `cycloid_config_repository` whose credential is also managed by Terraform in the same `terraform destroy` run — credential deletion should succeed on retry instead of failing with a 409 error

Fixes TFPRO-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)