### PR TITLE
fix(team_member): fix email attribute being ignored

### DIFF
--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -8,7 +8,11 @@ description: |-
 
 # cycloid_team_member (Resource)
 
-Assign an `orgnization_member` (user) to a team.
+Assign an `organization_member` (user) to a team.
+
+A member can be identified either by `username` (their canonical) or by `email`. Exactly one of the two must be provided.
+
+~> **Note:** When using `email`, the address must belong to an existing organization member (even if their invitation is still pending). To add someone to a team who is not yet part of the organization, first create a `cycloid_organization_member` resource for them.
 
 ## Example Usage
 
@@ -33,7 +37,7 @@ resource "cycloid_team_member" "lads" {
 resource "cycloid_team_member" "email_invite" {
   team         = cycloid_team.a_team.canonical
   organization = cycloid_team.a_team.organization
-  username     = "amy.allen@a-team.com"
+  email        = "amy.allen@a-team.com"
 }
 ```
 
@@ -46,6 +50,6 @@ resource "cycloid_team_member" "email_invite" {
 
 ### Optional
 
-- `email` (String) The email of the member to invite.
+- `email` (String) The email of the member to add. The email must belong to an existing organization member (even if their invitation is still pending). Mutually exclusive with `username`.
 - `organization` (String) The organization canonical of the team, default to the provider `default_organization`.
-- `username` (String) The username of the member to invite.
+- `username` (String) The canonical of the member to add. Mutually exclusive with `email`.

--- a/provider/team_member_resource.go
+++ b/provider/team_member_resource.go
@@ -12,6 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 var _ resource.Resource = &teamMemberResource{}
 
 type teamMemberResourceModel resource_team_member.TeamMemberModel
@@ -72,7 +79,7 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(teamMember.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
@@ -107,13 +114,13 @@ func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(teamMember.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
 
 	if teamMember == nil {
-		teamMember, _, err = m.AssignMemberToTeam(org, team, &username, &email)
+		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("failed to assign team member %q to team %q in org %q", Coalesce(username, email), team, org), err.Error())
 			return
@@ -155,13 +162,13 @@ func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(teamMember.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
 
 	if teamMember == nil {
-		teamMember, _, err = m.AssignMemberToTeam(org, team, &username, &email)
+		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("failed to assign team member %q to team %q in org %q", Coalesce(username, email), team, org), err.Error())
 			return
@@ -202,7 +209,7 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(teamMember.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}


### PR DESCRIPTION

- Pass nil to AssignMemberToTeam instead of pointer to empty string when username or email is not provided, fixing the 422 error when using the email attribute alone
- Fix nil pointer dereference in member lookup loop (teamMember.Email -> tm.Email) across Read, Create, Update and Delete
- Fix doc example using an email address as username value
- Clarify email/username attribute descriptions and add a note that email must belong to an existing organization member