### PR TITLE
Fix team member matching with empty identifiers

### DIFF
--- a/provider/team_member_resource.go
+++ b/provider/team_member_resource.go
@@ -77,16 +77,20 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
+	teamMember := findTeamMember(teamMembers, username, email)
+	if teamMember == nil {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	resp.Diagnostics.Append(
 		TeamMemberToModel(ctx, org, team, teamMember, &teamMemberState)...,
 	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &teamMemberState)...)
 }
 
 func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -112,12 +116,7 @@ func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember == nil {
 		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
@@ -160,12 +159,7 @@ func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember == nil {
 		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
@@ -207,12 +201,7 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember != nil {
 		_, err := m.UnAssignMemberFromTeam(org, team, ptr.Value(teamMember.ID))
@@ -243,6 +232,18 @@ func TeamMemberToModel(ctx context.Context, org, team string, teamMember *models
 		teamMemberState.Email = types.StringValue(ptr.Value(teamMember.Email).String())
 		teamMemberState.Organization = types.StringValue(org)
 		teamMemberState.Team = types.StringValue(team)
+	}
+	return nil
+}
+
+func findTeamMember(teamMembers []*models.MemberTeam, username, email string) *models.MemberTeam {
+	for _, teamMember := range teamMembers {
+		if username != "" && ptr.Value(teamMember.Username) == username {
+			return teamMember
+		}
+		if email != "" && ptr.Value(teamMember.Email).String() == email {
+			return teamMember
+		}
 	}
 	return nil
 }

--- a/provider/team_member_resource_test.go
+++ b/provider/team_member_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -61,6 +63,60 @@ func TestAccTeamMemberResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestFindTeamMemberIgnoresEmptyUsername(t *testing.T) {
+	firstUsername := ""
+	firstEmail := strfmt.Email("first@example.com")
+	expectedUsername := ""
+	expectedEmail := strfmt.Email("expected@example.com")
+
+	teamMembers := []*models.MemberTeam{
+		{
+			Username: &firstUsername,
+			Email:    &firstEmail,
+		},
+		{
+			Username: &expectedUsername,
+			Email:    &expectedEmail,
+		},
+	}
+
+	teamMember := findTeamMember(teamMembers, "", "expected@example.com")
+
+	if teamMember == nil {
+		t.Fatal("expected team member to be found")
+	}
+	if teamMember.Email == nil || teamMember.Email.String() != "expected@example.com" {
+		t.Fatalf("expected email %q, got %v", "expected@example.com", teamMember.Email)
+	}
+}
+
+func TestFindTeamMemberIgnoresEmptyEmail(t *testing.T) {
+	firstUsername := "first"
+	firstEmail := strfmt.Email("")
+	expectedUsername := "expected"
+	expectedEmail := strfmt.Email("")
+
+	teamMembers := []*models.MemberTeam{
+		{
+			Username: &firstUsername,
+			Email:    &firstEmail,
+		},
+		{
+			Username: &expectedUsername,
+			Email:    &expectedEmail,
+		},
+	}
+
+	teamMember := findTeamMember(teamMembers, "expected", "")
+
+	if teamMember == nil {
+		t.Fatal("expected team member to be found")
+	}
+	if teamMember.Username == nil || *teamMember.Username != "expected" {
+		t.Fatalf("expected username %q, got %v", "expected", teamMember.Username)
+	}
 }
 
 // Test configuration functions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reuses a single team-member lookup helper across read/create/update/delete.
- Ignores empty username/email values when matching listed team members, preventing email-only resources from selecting another member with an empty username.
- Updates `Read` to remove missing team-member resources from state and persist refreshed state when found.
- Adds regression coverage for email-only and username-only matching.

## Tests
- `go test ./provider -run 'TestFindTeamMember' -v`
- `go test ./... -run '^TestFindTeamMember' -v`
- `TESTS=$(go test ./provider -list '^Test' | rg '^Test' | rg -v '^TestAcc' | paste -sd '|' -); go test ./provider -run "^($TESTS)$" -v`
- `go vet ./...`
- `go build ./...`

## Notes
- `go test ./... -v` reaches unrelated acceptance setup and fails because `test_config.yaml`/`CY_TEST_CONFIG_FILE` is not configured for `TestAccEnvironmentResource` in this environment.
- `make build` cannot run because the VM is missing the `just` binary required by the Makefile wrapper; `go build ./...` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TFPRO-35](https://linear.app/cycloid/issue/TFPRO-35/terraform-inconsistency-error)

<div><a href="https://cursor.com/agents/bc-748dbcc8-8f94-4c2c-a432-4f83fa994740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-748dbcc8-8f94-4c2c-a432-4f83fa994740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

