### PR TITLE
fix(org_member): reconcile role when InviteMember returns existing membership (TFPRO-37)

### DIFF
--- a/provider/organization_member_resource.go
+++ b/provider/organization_member_resource.go
@@ -74,6 +74,21 @@ func (r *organizationMemberResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
+	// POST /organizations/{org}/members is idempotent: when the user is already a
+	// member of the org (e.g. auto-enrolled as organization-admin because they hold
+	// a root-org admin role) the API returns the existing membership with its current
+	// role rather than the requested one. Reconcile by forcing the requested role.
+	if m.Role != nil && m.Role.Canonical != nil && *m.Role.Canonical != role {
+		m, _, err = mid.UpdateMember(orgCan, uint32(*m.ID), role)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to set requested role on existing member",
+				err.Error(),
+			)
+			return
+		}
+	}
+
 	orgMemberCYModelToData(orgCan, m, &data)
 
 	// Save data into Terraform state

--- a/provider/organization_member_resource_test.go
+++ b/provider/organization_member_resource_test.go
@@ -40,6 +40,52 @@ func TestAccOrganizationMemberResource(t *testing.T) {
 	})
 }
 
+// TestAccOrganizationMemberResource_existingAdmin reproduces TFPRO-37: when the
+// invitee is already a member of the org with a different role (e.g. auto-enrolled
+// as organization-admin), InviteMember returns the existing role and the provider
+// previously crashed with "Provider produced inconsistent result after apply".
+func TestAccOrganizationMemberResource_existingAdmin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	memberEmail := fmt.Sprintf("test+%s@example.com", RandomCanonical(""))
+	orgCanonical := testAccGetOrganizationCanonical()
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	if depManager.provider.Middleware == nil {
+		t.Skip("skipping acceptance test: CY_API_URL, CY_API_KEY and CY_ORG must be set")
+	}
+
+	// Pre-invite as organization-admin outside of Terraform to simulate a user who
+	// is already a member with a higher role when TF first encounters them.
+	preInvite := func() {
+		if _, _, err := depManager.provider.Middleware.InviteMember(orgCanonical, memberEmail, "organization-admin"); err != nil {
+			t.Fatalf("pre-invite setup failed: %v", err)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				PreConfig: preInvite,
+				Config:    testAccOrganizationMemberConfig_basic(orgCanonical, memberEmail, "default-no-permissions"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_organization_member.test", "organization_canonical", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_organization_member.test", "email", memberEmail),
+					resource.TestCheckResourceAttr("cycloid_organization_member.test", "role_canonical", "default-no-permissions"),
+				),
+			},
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
 // Test configuration functions
 func testAccOrganizationMemberConfig_basic(org, email, role string) string {
 	return fmt.Sprintf(`
@@ -50,4 +96,3 @@ resource "cycloid_organization_member" "test" {
 }
 `, org, email, role)
 }
-


### PR DESCRIPTION
## Summary

Fixes **TFPRO-37** — `cycloid_organization_member` produces `Provider produced inconsistent result after apply` when the invitee is already a root-org admin.

**Root cause:** `POST /organizations/{org}/members` is idempotent — when the user is already a member (e.g. auto-enrolled as `organization-admin` because they hold a root-org admin role), the API returns the existing membership with its current role instead of the requested one. The provider was writing this API-returned role straight into state, causing a plan/state mismatch that the Terraform Plugin Framework rejects as a hard error.

**Fix:** After `InviteMember`, if the API returns a role different from the requested one, call `UpdateMember` to enforce the desired role before writing state. No-op in the common path.

**Test:** `TestAccOrganizationMemberResource_existingAdmin` pre-invites the test user as `organization-admin` via middleware (outside TF), then applies the resource with `role_canonical = "default-no-permissions"`. Without the fix this reproduces the customer error; with the fix both tests pass.

> **Note:** This PR is based on #85 and should be rebased/retargeted onto `master` once that merges.

## Test plan

- [x] `gofmt` clean on changed files
- [x] `go vet ./provider/` clean
- [x] `TestAccOrganizationMemberResource` — PASS (1.81s)
- [x] `TestAccOrganizationMemberResource_existingAdmin` — PASS (1.80s, reproduces TFPRO-37 without fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)