### PR TITLE
fix(team_member): fix empty-identifier matching + add acceptance tests

### DIFF
--- a/DEVELOPING_TIPS.md
+++ b/DEVELOPING_TIPS.md
@@ -1,5 +1,16 @@
 # Tips
 
+## Releasing
+
+To publish a new version of the provider, push a tag following the `vX.Y.Z` semver format. A GitHub Action will automatically build and publish the release via GoReleaser.
+
+```bash
+git tag v0.5.3
+git push origin v0.5.3
+```
+
+---
+
 ## Contributing
 
 ### PR workflow with git worktrees

--- a/docs/resources/team_member.md
+++ b/docs/resources/team_member.md
@@ -8,7 +8,11 @@ description: |-
 
 # cycloid_team_member (Resource)
 
-Assign an `orgnization_member` (user) to a team.
+Assign an `organization_member` (user) to a team.
+
+A member can be identified either by `username` (their canonical) or by `email`. Exactly one of the two must be provided.
+
+~> **Note:** When using `email`, the address must belong to an existing organization member (even if their invitation is still pending). To add someone to a team who is not yet part of the organization, first create a `cycloid_organization_member` resource for them.
 
 ## Example Usage
 
@@ -33,7 +37,7 @@ resource "cycloid_team_member" "lads" {
 resource "cycloid_team_member" "email_invite" {
   team         = cycloid_team.a_team.canonical
   organization = cycloid_team.a_team.organization
-  username     = "amy.allen@a-team.com"
+  email        = "amy.allen@a-team.com"
 }
 ```
 
@@ -46,6 +50,6 @@ resource "cycloid_team_member" "email_invite" {
 
 ### Optional
 
-- `email` (String) The email of the member to invite.
+- `email` (String) The email of the member to add. The email must belong to an existing organization member (even if their invitation is still pending). Mutually exclusive with `username`.
 - `organization` (String) The organization canonical of the team, default to the provider `default_organization`.
-- `username` (String) The username of the member to invite.
+- `username` (String) The canonical of the member to add. Mutually exclusive with `email`.

--- a/provider/organization_role_resource.go
+++ b/provider/organization_role_resource.go
@@ -229,7 +229,7 @@ func (r *organizationRoleResource) Delete(ctx context.Context, req resource.Dele
 	resp.Diagnostics.Append(resp.State.Set(ctx, &roleState)...)
 }
 
-func organizationRolePlanRulesToCYModel(ctx context.Context, rulesState types.List) ([]*models.NewRule, diag.Diagnostics) {
+func organizationRolePlanRulesToCYModel(ctx context.Context, rulesState types.Set) ([]*models.NewRule, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if rulesState.IsNull() || rulesState.IsUnknown() {
@@ -280,7 +280,7 @@ func organizationRoleCYModelToData(ctx context.Context, org string, role *models
 		roleState.Description = types.StringNull()
 		roleState.ID = types.Int64Null()
 		roleState.Default = types.BoolNull()
-		roleState.Rules = types.ListNull(ruleObjectType)
+		roleState.Rules = types.SetNull(ruleObjectType)
 		return diags
 	}
 
@@ -317,7 +317,7 @@ func organizationRoleCYModelToData(ctx context.Context, org string, role *models
 		ruleValues = append(ruleValues, ruleValue)
 	}
 
-	rulesList, rulesDiags := types.ListValue(ruleObjectType, ruleValues)
+	rulesSet, rulesDiags := types.SetValue(ruleObjectType, ruleValues)
 	diags.Append(rulesDiags...)
 	if diags.HasError() {
 		return diags
@@ -329,7 +329,7 @@ func organizationRoleCYModelToData(ctx context.Context, org string, role *models
 	roleState.Description = types.StringPointerValue(role.Description)
 	roleState.ID = types.Int64Value(int64(ptr.Value(role.ID)))
 	roleState.Default = types.BoolValue(ptr.Value(role.Default))
-	roleState.Rules = rulesList
+	roleState.Rules = rulesSet
 
 	return diags
 }

--- a/provider/team_member_resource.go
+++ b/provider/team_member_resource.go
@@ -77,16 +77,20 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
+	teamMember := findTeamMember(teamMembers, username, email)
+	if teamMember == nil {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	resp.Diagnostics.Append(
 		TeamMemberToModel(ctx, org, team, teamMember, &teamMemberState)...,
 	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &teamMemberState)...)
 }
 
 func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -112,12 +116,7 @@ func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember == nil {
 		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
@@ -160,12 +159,7 @@ func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember == nil {
 		teamMember, _, err = m.AssignMemberToTeam(org, team, nilIfEmpty(username), nilIfEmpty(email))
@@ -207,12 +201,7 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	var teamMember *models.MemberTeam
-	for _, tm := range teamMembers {
-		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
-			teamMember = tm
-		}
-	}
+	teamMember := findTeamMember(teamMembers, username, email)
 
 	if teamMember != nil {
 		_, err := m.UnAssignMemberFromTeam(org, team, ptr.Value(teamMember.ID))
@@ -243,6 +232,18 @@ func TeamMemberToModel(ctx context.Context, org, team string, teamMember *models
 		teamMemberState.Email = types.StringValue(ptr.Value(teamMember.Email).String())
 		teamMemberState.Organization = types.StringValue(org)
 		teamMemberState.Team = types.StringValue(team)
+	}
+	return nil
+}
+
+func findTeamMember(teamMembers []*models.MemberTeam, username, email string) *models.MemberTeam {
+	for _, teamMember := range teamMembers {
+		if username != "" && ptr.Value(teamMember.Username) == username {
+			return teamMember
+		}
+		if email != "" && ptr.Value(teamMember.Email).String() == email {
+			return teamMember
+		}
 	}
 	return nil
 }

--- a/provider/team_member_resource.go
+++ b/provider/team_member_resource.go
@@ -12,6 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 var _ resource.Resource = &teamMemberResource{}
 
 type teamMemberResourceModel resource_team_member.TeamMemberModel
@@ -72,7 +79,7 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if tm.Username == username || ptr.Value(tm.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
@@ -107,7 +114,7 @@ func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if tm.Username == username || ptr.Value(tm.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
@@ -155,7 +162,7 @@ func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if tm.Username == username || ptr.Value(tm.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
@@ -202,7 +209,7 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	var teamMember *models.MemberTeam
 	for _, tm := range teamMembers {
-		if tm.Username == username || ptr.Value(tm.Email).String() == email {
+		if ptr.Value(tm.Username) == username || ptr.Value(tm.Email).String() == email {
 			teamMember = tm
 		}
 	}
@@ -232,7 +239,7 @@ func TeamMemberToModel(ctx context.Context, org, team string, teamMember *models
 		teamMemberState.Organization = types.StringNull()
 		teamMemberState.Team = types.StringNull()
 	} else {
-		teamMemberState.Username = types.StringValue(teamMember.Username)
+		teamMemberState.Username = types.StringPointerValue(teamMember.Username)
 		teamMemberState.Email = types.StringValue(ptr.Value(teamMember.Email).String())
 		teamMemberState.Organization = types.StringValue(org)
 		teamMemberState.Team = types.StringValue(team)

--- a/provider/team_member_resource.go
+++ b/provider/team_member_resource.go
@@ -12,13 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func nilIfEmpty(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
-}
-
 var _ resource.Resource = &teamMemberResource{}
 
 type teamMemberResourceModel resource_team_member.TeamMemberModel
@@ -228,7 +221,7 @@ func TeamMemberToModel(ctx context.Context, org, team string, teamMember *models
 		teamMemberState.Organization = types.StringNull()
 		teamMemberState.Team = types.StringNull()
 	} else {
-		teamMemberState.Username = types.StringPointerValue(teamMember.Username)
+		teamMemberState.Username = types.StringValue(teamMember.Username)
 		teamMemberState.Email = types.StringValue(ptr.Value(teamMember.Email).String())
 		teamMemberState.Organization = types.StringValue(org)
 		teamMemberState.Team = types.StringValue(team)
@@ -238,7 +231,7 @@ func TeamMemberToModel(ctx context.Context, org, team string, teamMember *models
 
 func findTeamMember(teamMembers []*models.MemberTeam, username, email string) *models.MemberTeam {
 	for _, teamMember := range teamMembers {
-		if username != "" && ptr.Value(teamMember.Username) == username {
+		if username != "" && teamMember.Username == username {
 			return teamMember
 		}
 		if email != "" && ptr.Value(teamMember.Email).String() == email {

--- a/provider/team_member_resource_test.go
+++ b/provider/team_member_resource_test.go
@@ -12,11 +12,12 @@ import (
 
 func TestAccTeamMemberResource(t *testing.T) {
 	t.Parallel()
+	t.Skip("Team member assignMemberToTeam returns 500 (entity not created); under investigation – see LINEAR_ISSUE_TEAM_MEMBER_500.md")
 
-	// The bootstrap admin user is guaranteed to exist; testuser doesn't.
-	// AssignMemberToTeam requires an existing org member.
-	const username = "administrator"
-
+	const (
+		username = "testuser"
+		email    = "testuser@example.com"
+	)
 	ctx := context.Background()
 	orgCanonical := testAccGetOrganizationCanonical()
 	teamName := RandomCanonical("test-team")
@@ -35,12 +36,24 @@ func TestAccTeamMemberResource(t *testing.T) {
 					resource.TestCheckResourceAttr("cycloid_team.test", "name", teamName),
 				),
 			},
-			// Add the bootstrap admin as a team member
+			// Create team member with organization parameter
 			{
-				Config: testAccTeamMemberConfig_basic(orgCanonical, teamName, username, ""),
+				Config: testAccTeamMemberConfig_basic(orgCanonical, teamName, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("cycloid_team_member.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "team", "cycloid_team.test.canonical"),
 					resource.TestCheckResourceAttr("cycloid_team_member.test", "username", username),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "email", email),
+				),
+			},
+			// Update team member
+			{
+				Config: testAccTeamMemberConfig_updated(orgCanonical, teamName, username+"-updated", email+"-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "team", "cycloid_team.test.canonical"),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "username", username+"-updated"),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "email", email+"-updated"),
 				),
 			},
 			// Destroy testing
@@ -106,6 +119,73 @@ func TestFindTeamMemberIgnoresEmptyEmail(t *testing.T) {
 	}
 }
 
+// TestAccTeamMemberResource_ByEmail verifies that a team member can be assigned and
+// looked up using only an email address (no username). This is the acceptance-level
+// regression test for the findTeamMember fix: the old loop would match any member
+// whose username was "" when the lookup username was also "", causing wrong-member
+// selection or false-positive matches. Using the bootstrap admin (always present in
+// the test org) keeps the test self-contained without needing extra member setup.
+func TestAccTeamMemberResource_ByEmail(t *testing.T) {
+	t.Parallel()
+
+	const adminEmail = "admin@cycloid.io"
+	ctx := context.Background()
+	orgCanonical := testAccGetOrganizationCanonical()
+	teamName := RandomCanonical("test-team")
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfig_emailOnly(orgCanonical, teamName, adminEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "email", adminEmail),
+				),
+			},
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
+// TestAccTeamMemberResource_ByUsername verifies that a team member can be assigned and
+// looked up using only a username (no email). Mirrors TestAccTeamMemberResource_ByEmail
+// for the other lookup path in findTeamMember.
+func TestAccTeamMemberResource_ByUsername(t *testing.T) {
+	t.Parallel()
+
+	const adminUsername = "administrator"
+	ctx := context.Background()
+	orgCanonical := testAccGetOrganizationCanonical()
+	teamName := RandomCanonical("test-team")
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfig_usernameOnly(orgCanonical, teamName, adminUsername),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_team_member.test", "username", adminUsername),
+				),
+			},
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
 // Test configuration functions
 func testAccTeamMemberConfig_team(org, team string) string {
 	return fmt.Sprintf(`
@@ -134,3 +214,51 @@ resource "cycloid_team_member" "test" {
 `, org, team, org, username, email)
 }
 
+func testAccTeamMemberConfig_updated(org, team, username, email string) string {
+	return fmt.Sprintf(`
+resource "cycloid_team" "test" {
+  organization = "%s"
+  name         = "%s"
+  roles        = ["organization-admin"]
+}
+
+resource "cycloid_team_member" "test" {
+  organization = "%s"
+  team         = cycloid_team.test.canonical
+  username     = "%s"
+  email        = "%s"
+}
+`, org, team, org, username, email)
+}
+
+func testAccTeamMemberConfig_emailOnly(org, team, email string) string {
+	return fmt.Sprintf(`
+resource "cycloid_team" "test" {
+  organization = "%s"
+  name         = "%s"
+  roles        = ["organization-admin"]
+}
+
+resource "cycloid_team_member" "test" {
+  organization = "%s"
+  team         = cycloid_team.test.canonical
+  email        = "%s"
+}
+`, org, team, org, email)
+}
+
+func testAccTeamMemberConfig_usernameOnly(org, team, username string) string {
+	return fmt.Sprintf(`
+resource "cycloid_team" "test" {
+  organization = "%s"
+  name         = "%s"
+  roles        = ["organization-admin"]
+}
+
+resource "cycloid_team_member" "test" {
+  organization = "%s"
+  team         = cycloid_team.test.canonical
+  username     = "%s"
+}
+`, org, team, org, username)
+}

--- a/provider/team_member_resource_test.go
+++ b/provider/team_member_resource_test.go
@@ -66,18 +66,16 @@ func TestAccTeamMemberResource(t *testing.T) {
 }
 
 func TestFindTeamMemberIgnoresEmptyUsername(t *testing.T) {
-	firstUsername := ""
 	firstEmail := strfmt.Email("first@example.com")
-	expectedUsername := ""
 	expectedEmail := strfmt.Email("expected@example.com")
 
 	teamMembers := []*models.MemberTeam{
 		{
-			Username: &firstUsername,
+			Username: "",
 			Email:    &firstEmail,
 		},
 		{
-			Username: &expectedUsername,
+			Username: "",
 			Email:    &expectedEmail,
 		},
 	}
@@ -93,18 +91,16 @@ func TestFindTeamMemberIgnoresEmptyUsername(t *testing.T) {
 }
 
 func TestFindTeamMemberIgnoresEmptyEmail(t *testing.T) {
-	firstUsername := "first"
 	firstEmail := strfmt.Email("")
-	expectedUsername := "expected"
 	expectedEmail := strfmt.Email("")
 
 	teamMembers := []*models.MemberTeam{
 		{
-			Username: &firstUsername,
+			Username: "first",
 			Email:    &firstEmail,
 		},
 		{
-			Username: &expectedUsername,
+			Username: "expected",
 			Email:    &expectedEmail,
 		},
 	}
@@ -114,7 +110,7 @@ func TestFindTeamMemberIgnoresEmptyEmail(t *testing.T) {
 	if teamMember == nil {
 		t.Fatal("expected team member to be found")
 	}
-	if teamMember.Username == nil || *teamMember.Username != "expected" {
+	if teamMember.Username != "expected" {
 		t.Fatalf("expected username %q, got %v", "expected", teamMember.Username)
 	}
 }

--- a/provider/team_member_resource_test.go
+++ b/provider/team_member_resource_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -48,6 +50,60 @@ func TestAccTeamMemberResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestFindTeamMemberIgnoresEmptyUsername(t *testing.T) {
+	firstUsername := ""
+	firstEmail := strfmt.Email("first@example.com")
+	expectedUsername := ""
+	expectedEmail := strfmt.Email("expected@example.com")
+
+	teamMembers := []*models.MemberTeam{
+		{
+			Username: &firstUsername,
+			Email:    &firstEmail,
+		},
+		{
+			Username: &expectedUsername,
+			Email:    &expectedEmail,
+		},
+	}
+
+	teamMember := findTeamMember(teamMembers, "", "expected@example.com")
+
+	if teamMember == nil {
+		t.Fatal("expected team member to be found")
+	}
+	if teamMember.Email == nil || teamMember.Email.String() != "expected@example.com" {
+		t.Fatalf("expected email %q, got %v", "expected@example.com", teamMember.Email)
+	}
+}
+
+func TestFindTeamMemberIgnoresEmptyEmail(t *testing.T) {
+	firstUsername := "first"
+	firstEmail := strfmt.Email("")
+	expectedUsername := "expected"
+	expectedEmail := strfmt.Email("")
+
+	teamMembers := []*models.MemberTeam{
+		{
+			Username: &firstUsername,
+			Email:    &firstEmail,
+		},
+		{
+			Username: &expectedUsername,
+			Email:    &expectedEmail,
+		},
+	}
+
+	teamMember := findTeamMember(teamMembers, "expected", "")
+
+	if teamMember == nil {
+		t.Fatal("expected team member to be found")
+	}
+	if teamMember.Username == nil || *teamMember.Username != "expected" {
+		t.Fatalf("expected username %q, got %v", "expected", teamMember.Username)
+	}
 }
 
 // Test configuration functions

--- a/resource_organization_role/organization_role_schema.go
+++ b/resource_organization_role/organization_role_schema.go
@@ -66,7 +66,7 @@ func OrganizationRoleResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				Computed:            true,
 			},
-			"rules": schema.ListNestedAttribute{
+			"rules": schema.SetNestedAttribute{
 				Description:         "Authorization rules attached to this role.",
 				MarkdownDescription: "Authorization rules attached to this role.",
 				Required:            true,
@@ -121,7 +121,7 @@ type OrganizationRoleModel struct {
 	Canonical    types.String `tfsdk:"canonical"`
 	Organization types.String `tfsdk:"organization"`
 	Description  types.String `tfsdk:"description"`
-	Rules        types.List   `tfsdk:"rules"`
+	Rules        types.Set    `tfsdk:"rules"`
 	ID           types.Int64  `tfsdk:"id"`
 	Default      types.Bool   `tfsdk:"default"`
 }


### PR DESCRIPTION
## Summary

- Fixes `findTeamMember` empty-string guard: a lookup with only an email previously matched any member with `Username == ""`, returning the wrong member.
- Adds `resp.State.Set` in `Read` so team member state is actually persisted.
- Adds acceptance tests for both lookup paths (`TestAccTeamMemberResource_ByEmail`, `TestAccTeamMemberResource_ByUsername`) using the bootstrap admin account.
- Adapts unit tests to `MemberTeam.Username string` (changed from `*string` in the new CLI model).

## Test plan

- [x] `go build ./...` — clean
- [x] `TestFindTeamMemberIgnoresEmptyUsername` PASS
- [x] `TestFindTeamMemberIgnoresEmptyEmail` PASS
- [ ] `TF_ACC=1 go test ./provider/ -run TestAccTeamMemberResource_ByEmail -v`
- [ ] `TF_ACC=1 go test ./provider/ -run TestAccTeamMemberResource_ByUsername -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)