### PR TITLE
docs: add just install and unit test gotcha notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ To test the provider with Terraform, create a dev override file (see `README.md`
 - Use `make install-provider` or `go install .` for the provider binary. Note: `make install` installs codegen tools, not the provider itself.
 - All provider operations require a remote Cycloid API (`CY_API_URL`, `CY_API_KEY`, `CY_ORG` env vars). A dedicated testing environment is used for tests — do not run against production. No local services to start.
 - `staticcheck` reports pre-existing warnings (unused vars/funcs); these are not blockers.
+- `just` (command runner) is required for Makefile targets. Install via `curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin`.
+- Unit tests (`go test ./... -short`) will show `TestAccEnvironmentResource` as FAIL — this is a pre-existing bug where the test doesn't skip in non-acceptance mode. All actual unit tests pass. Use `-run 'Test[^A]|TestA[^c]'` to exclude acceptance tests cleanly, or just ignore that single failure.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two clarifications to the "Cursor Cloud specific instructions" section of `AGENTS.md`:

1. **`just` command runner** — documents how to install `just`, which is required by the `Makefile` (all targets delegate to `just`).
2. **Pre-existing unit test failure** — documents that `TestAccEnvironmentResource` fails during `go test ./... -short` because it doesn't properly skip in non-acceptance mode. All actual unit tests pass.

### Evidence of working dev environment

Build, lint, test, and Terraform plan all working:

[full_dev_setup_output.log](https://cursor.com/agents/bc-158a7ab9-47b0-4a01-88e8-1a1b955e12a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_dev_setup_output.log)

Terraform provider dev override working:

[terraform_plan_output.log](https://cursor.com/agents/bc-158a7ab9-47b0-4a01-88e8-1a1b955e12a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fterraform_plan_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-158a7ab9-47b0-4a01-88e8-1a1b955e12a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-158a7ab9-47b0-4a01-88e8-1a1b955e12a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

