### PR TITLE
feat: plugin resources suite + organization_members datasource (v0.7.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,18 +125,24 @@ To test the provider with Terraform, create a dev override file (see `README.md`
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **terraform-provider-cycloid** (3240 symbols, 6071 relationships, 141 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **terraform-provider-cycloid** (3316 symbols, 6205 relationships, 142 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## When GitNexus is Available
+## Always Do
 
-- Before modifying a symbol, prefer running `gitnexus_impact({target: "symbolName", direction: "upstream"})` to understand callers and blast radius.
-- Before committing, consider running `gitnexus_detect_changes()` to verify the affected scope matches expectations.
-- If impact analysis returns HIGH or CRITICAL risk, surface it to the user before proceeding.
-- When exploring unfamiliar code, prefer `gitnexus_query({query: "concept"})` over grepping — it returns process-grouped results ranked by relevance.
-- For full context on a specific symbol — callers, callees, execution flows — use `gitnexus_context({name: "symbolName"})`.
-- Prefer `gitnexus_rename` over find-and-replace for symbol renames — it understands the call graph.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,26 @@
 
 ## Unreleased
 
+## v0.7.0
+
 ### Added
-- Local docker-compose stack (`compose.yml`) mirroring cycloid-cli's 12-service QA stack
-  (youdeploy-api, plugin-manager, plugin-registry, docker-registry, concourse, vault,
-  redis, mysql, git-server, mailpit). Managed via `just be-start / be-stop / be-reset`.
-- Acceptance test bootstrap via `TestMain` — calls `testcfg.NewConfig` (from
-  `cycloid-cli/pkg/testcfg`) to provision admin user, API key, config repo, catalog repo,
-  test project, environment, and component automatically on `just be-start`.
-- `.env.sample` and `just env` recipe for secret resolution via `cy uri interpolate`
-  (mirrors `cycloid-cli` `make .env`).
-- `just test-acc-fresh` recipe: one-shot path from cold docker state to green test suite.
-- Acceptance tests for 5 plugin resources: `cycloid_plugin_registry`,
-  `cycloid_plugin_manager`, `cycloid_plugin_registry_plugin`, `cycloid_plugin_version`,
-  `cycloid_plugin` (full install → running → uninstall lifecycle).
-- `ensurePluginHelloWorld` helper: idempotent pull/tag/push of
-  `docker.io/cycloid/plugin-hello-world:1.0.0` to the local docker-registry.
 
-### Changed
-- `TESTING.md` rewritten: local docker-compose stack is now the primary test path.
-  Remote env override path documented as secondary.
-- `go.mod` now consumes `cycloid-cli/pkg/testcfg` (promoted from `internal/testcfg`).
-
-### Deprecated
-- `TEST_DEPENDENCIES_ACC_RUN.md` (remote-env workflow notes) — kept for reference,
-  will be removed in a future cycle.
-- `test_config.yaml` / `README_TEST_CONFIG.md` — no longer required for local stack runs.
+- **`cycloid_plugin_manager` resource** — manage plugin-manager registration and lifecycle
+  (create, import, destroy). Auto-registers the manager with the Cycloid org on create via
+  `auto_register = true`; supports `wait_until_connected` to block until the manager
+  reports a connected status.
+- **`cycloid_plugin_registry` resource** — register and manage plugin registries.
+- **`cycloid_plugin_registry_plugin` resource** — associate a plugin with a registry.
+- **`cycloid_plugin_version` resource** — manage plugin versions within a registry plugin.
+- **`cycloid_plugin` resource** — full plugin install/uninstall lifecycle (pulls image from
+  registry, deploys to plugin-manager, tracks running status).
+- **`cycloid_organization_members` data source** — list members of a Cycloid organisation
+  with optional role filtering.
 
 ### Fixed
-- `provider/stack_datasource_test.go`: removed non-existent `QuotaEnabled` field from
-  `models.ServiceCatalog` literal (pre-existing `go vet` failure).
+
+- `cycloid_plugin_manager`: `auto_register` is now always `true` and not exposed as a
+  configurable attribute (CLI-121). Previous versions required an explicit `accept` step
+  that left the manager in `invite_pending` if the CLI didn't set `auto_register`.
+- `cycloid_plugin_manager`: `status` field correctly handles both string and numeric values
+  returned by different backend versions (workaround for v6.10.8-rc backend).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,12 @@
 
 ## Unreleased
 
-## v0.7.0
-
-### Added
-
-- **`cycloid_plugin_manager` resource** — manage plugin-manager registration and lifecycle
-  (create, import, destroy). Auto-registers the manager with the Cycloid org on create via
-  `auto_register = true`; supports `wait_until_connected` to block until the manager
-  reports a connected status.
-- **`cycloid_plugin_registry` resource** — register and manage plugin registries.
-- **`cycloid_plugin_registry_plugin` resource** — associate a plugin with a registry.
-- **`cycloid_plugin_version` resource** — manage plugin versions within a registry plugin.
-- **`cycloid_plugin` resource** — full plugin install/uninstall lifecycle (pulls image from
-  registry, deploys to plugin-manager, tracks running status).
-- **`cycloid_organization_members` data source** — list members of a Cycloid organisation
-  with optional role filtering.
+## v0.6.1
 
 ### Fixed
 
-- `cycloid_plugin_manager`: `auto_register` is now always `true` and not exposed as a
-  configurable attribute (CLI-121). Previous versions required an explicit `accept` step
-  that left the manager in `invite_pending` if the CLI didn't set `auto_register`.
-- `cycloid_plugin_manager`: `status` field correctly handles both string and numeric values
-  returned by different backend versions (workaround for v6.10.8-rc backend).
+- **`cycloid_plugin_manager`**: registration no longer gets stuck in "invite pending" —
+  the manager is now auto-registered with the Cycloid organisation on create, with no
+  manual accept step required.
+- **`cycloid_plugin_manager`**: `status` field now handles both string and numeric values
+  returned by different backend versions, preventing plan failures after a backend upgrade.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **terraform-provider-cycloid** (3240 symbols, 6071 relationships, 141 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **terraform-provider-cycloid** (3316 symbols, 6205 relationships, 142 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
-## When GitNexus is Available
+## Always Do
 
-- Before modifying a symbol, prefer running `gitnexus_impact({target: "symbolName", direction: "upstream"})` to understand callers and blast radius.
-- Before committing, consider running `gitnexus_detect_changes()` to verify the affected scope matches expectations.
-- If impact analysis returns HIGH or CRITICAL risk, surface it to the user before proceeding.
-- When exploring unfamiliar code, prefer `gitnexus_query({query: "concept"})` over grepping — it returns process-grouped results ranked by relevance.
-- For full context on a specific symbol — callers, callees, execution flows — use `gitnexus_context({name: "symbolName"})`.
-- Prefer `gitnexus_rename` over find-and-replace for symbol renames — it understands the call graph.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/compose.yml
+++ b/compose.yml
@@ -4,19 +4,19 @@ services:
     image: rg.fr-par.scw.cloud/cycloidio/cycloid-backend:${BACKEND_TAG:-staging}
     healthcheck:
       test:
-      - "CMD-SHELL"
-      - |
-        test \
-          "$(curl -s http://localhost:3001/status \
-             | jq -r '.data.checks | map(select((.canonical | contains("database", "pipeline", "secret")) and .status == "Success")) | length' \
-           )" = "3"
+        - "CMD-SHELL"
+        - |
+          test \
+            "$(curl -s http://localhost:3001/status \
+               | jq -r '.data.checks | map(select((.canonical | contains("database", "pipeline", "secret")) and .status == "Success")) | length' \
+             )" = "3"
       start_period: 5s
       interval: 3s
       timeout: 45s
       retries: 30
 
     ports:
-    - 3001:3001
+      - 3001:3001
     ulimits:
       nproc: 65535
       nofile:
@@ -25,22 +25,22 @@ services:
 
     working_dir: /go/src/github.com/cycloidio/youdeploy-http-api
     configs:
-    - source: youdeploy-config.yml
-      target: /ci/config.yml
+      - source: youdeploy-config.yml
+        target: /ci/config.yml
     entrypoint:
-    - bash
-    - -ec
-    - |
-      echo -e "# \e[33mDB migrate ...\e[0m"
-      timeout 120 bash -c '
-        until /go/youdeploy-http-api migrate up --config-file /ci/config.yml --migrations-dir /opt/migrations --db-name=youdeploy_fake && echo "ok"; do
-          >&2 echo -e "\e[36mWaiting for DB migrations\e[0m"
-          sleep 1
-        done
-      '
+      - bash
+      - -ec
+      - |
+        echo -e "# \e[33mDB migrate ...\e[0m"
+        timeout 120 bash -c '
+          until /go/youdeploy-http-api migrate up --config-file /ci/config.yml --migrations-dir /opt/migrations --db-name=youdeploy_fake && echo "ok"; do
+            >&2 echo -e "\e[36mWaiting for DB migrations\e[0m"
+            sleep 1
+          done
+        '
 
-      echo -e "# \e[33mRunning Cycloid API ...\e[0m"
-      exec /go/youdeploy-http-api server --config-file /ci/config.yml
+        echo -e "# \e[33mRunning Cycloid API ...\e[0m"
+        exec /go/youdeploy-http-api server --config-file /ci/config.yml
 
     networks:
       - cycloid
@@ -59,13 +59,22 @@ services:
     image: mysql:9.3.0
     platform: linux/x86_64
     configs:
-    - source: my.cnf
-      target: /etc/my.cnf
+      - source: my.cnf
+        target: /etc/my.cnf
     environment:
       MYSQL_ROOT_PASSWORD: youdeploy
       MYSQL_DATABASE: youdeploy
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "database", "-P3306", "-p=${MYSQL_ROOT_PASSWORD:-youdeploy}"]
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "database",
+          "-P3306",
+          "-p=${MYSQL_ROOT_PASSWORD:-youdeploy}",
+        ]
       start_period: 5s
       interval: 1s
       timeout: 30s
@@ -110,55 +119,53 @@ services:
       VAULT_TOKEN: root_token
       VAULT_SKIP_VERIFY: true
     entrypoint:
-    - sh
-    - -ec
-    - |
-      # This script must be idempotent
-      until vault login "$${VAULT_TOKEN:?}" ; do
-        >&2 echo -e "Waiting for Vault..."
-        sleep 1
-      done
+      - sh
+      - -ec
+      - |
+        # This script must be idempotent
+        until vault login "$${VAULT_TOKEN:?}" ; do
+          >&2 echo -e "Waiting for Vault..."
+          sleep 1
+        done
 
-      vault auth enable approle || true
-      vault write sys/mounts/cycloid type=kv >/dev/null 2>&1 || true
-      vault write sys/policy/cycloid policy=@policy.hcl >/dev/null 2>&1
-      vault write auth/approle/role/cycloid token_ttl=20m token_max_ttl=1h policies=cycloid >/dev/null 2>&1
-      vault write auth/approle/role/cycloid/role-id role_id=custom-role-id >/dev/null 2>&1
-      vault write auth/approle/role/cycloid/custom-secret-id secret_id=custom-secret-id >/dev/null 2>&1 || true
+        vault auth enable approle || true
+        vault write sys/mounts/cycloid type=kv >/dev/null 2>&1 || true
+        vault write sys/policy/cycloid policy=@policy.hcl >/dev/null 2>&1
+        vault write auth/approle/role/cycloid token_ttl=20m token_max_ttl=1h policies=cycloid >/dev/null 2>&1
+        vault write auth/approle/role/cycloid/role-id role_id=custom-role-id >/dev/null 2>&1
+        vault write auth/approle/role/cycloid/custom-secret-id secret_id=custom-secret-id >/dev/null 2>&1 || true
 
     networks:
       - cycloid
-
 
   redis:
     image: redis:8.0.2
     command:
-    # Port 6379 defaults to TLS, change ports to keep tests pass
-    - --port
-    - "6379"
-    - --tls-port
-    - "6383"
-    # Provide self-signed certificate to REDIS TLS
-    - --tls-ca-cert-file
-    - /etc/redis/tls/cert
-    - --tls-cert-file
-    - /etc/redis/tls/cert
-    - --tls-key-file
-    - /etc/redis/tls/key
-    - --tls-auth-clients
-    - no
+      # Port 6379 defaults to TLS, change ports to keep tests pass
+      - --port
+      - "6379"
+      - --tls-port
+      - "6383"
+      # Provide self-signed certificate to REDIS TLS
+      - --tls-ca-cert-file
+      - /etc/redis/tls/cert
+      - --tls-cert-file
+      - /etc/redis/tls/cert
+      - --tls-key-file
+      - /etc/redis/tls/key
+      - --tls-auth-clients
+      - no
     # Configuration Environment for REDIS with self-signed TLS
     # Didn't found anything for that
     # - ALLOW_EMPTY_PASSWORD=true
     configs:
-    - source: redisTLSCert
-      target: /etc/redis/tls/cert
-    - source: redisTLSKey
-      target: /etc/redis/tls/key
+      - source: redisTLSCert
+        target: /etc/redis/tls/cert
+      - source: redisTLSKey
+        target: /etc/redis/tls/key
     tmpfs: [/data]
     networks:
       - cycloid
-
 
   git-server:
     image: cycloid/backend-tests-git-server:latest
@@ -167,8 +174,8 @@ services:
     networks:
       - cycloid
     tmpfs:
-    - /git-server/repos:exec
-    - /git-server/keys
+      - /git-server/repos:exec
+      - /git-server/keys
 
   ## Concourse
   concourse-db:
@@ -192,18 +199,18 @@ services:
     networks:
       - cycloid
     configs:
-    - source: base_resource_types_defaults.yml
-      target: /brt/base_resource_types_defaults.yml
-    - source: authorized_worker_keys
-      target: /concourse-keys/authorized_worker_keys
-    - source: session_signing_key
-      target: /concourse-keys/session_signing_key
-    - source: session_signing_key.pub
-      target: /concourse-keys/session_signing_key.pub
-    - source: tsa_host_key
-      target: /concourse-keys/tsa_host_key
-    - source: tsa_host_key.pub
-      target: /concourse-keys/tsa_host_key.pub
+      - source: base_resource_types_defaults.yml
+        target: /brt/base_resource_types_defaults.yml
+      - source: authorized_worker_keys
+        target: /concourse-keys/authorized_worker_keys
+      - source: session_signing_key
+        target: /concourse-keys/session_signing_key
+      - source: session_signing_key.pub
+        target: /concourse-keys/session_signing_key.pub
+      - source: tsa_host_key
+        target: /concourse-keys/tsa_host_key
+      - source: tsa_host_key.pub
+        target: /concourse-keys/tsa_host_key.pub
     restart: unless-stopped # required so that it retries until concourse-db comes up
     environment:
       CONCOURSE_ADD_LOCAL_USER: concourse:concourse
@@ -278,7 +285,6 @@ services:
       REDIS_URI: redis://redis:6379
       CY_URL: http://youdeploy-api:3001
       CY_TOKEN_SECRET: local-test-secret
-      ORGS_CANS: cycloid
       ADMIN_USERNAME: cycloid
       ADMIN_PASSWORD: cycloid123
       RUN_MIGRATIONS: "true"
@@ -538,4 +544,3 @@ configs:
 
 networks:
   cycloid: {}
-

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/cycloidio/cycloid-cli v1.0.98-0.20260521134546-e6696670a27b
+	github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260521134546-e6696670a27b h1:sZYvG0PoZ4pYKOth9XFCwpl4x+CqYU5yrZuOOQo/Qys=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260521134546-e6696670a27b/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758 h1:Rqbmh2jvsQWDXGMQjkVJx7F+3vvDEqZI+0bvgxPludU=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

- **5 new plugin resources**: `cycloid_plugin_manager`, `cycloid_plugin_registry`, `cycloid_plugin_registry_plugin`, `cycloid_plugin_version`, `cycloid_plugin` — full plugin install/uninstall lifecycle
- **1 new datasource**: `cycloid_organization_members`
- **plugin_manager fix**: `auto_register` is now always true and not exposed (CLI-121); fixes invite-pending orphan bug (ENGBE-266)
- **Dep bump**: cycloid-cli → ab3d5fb (testcfg non-fatal env fixture + PluginManager.status UnmarshalJSON for v6.10.8-rc)
- **compose fix**: removed `ORGS_CANS` from plugin-manager service — fixes `TestAccPluginManagerResource_Create` duplicate-key collision (ENG-151)

Closes TFPRO-41

## Test plan

- [x] `TestAccPluginManagerResource_Create` — **PASS** (was failing with 1062 duplicate key before ORGS_CANS removal)
- [x] `TestAccPluginManagerResource` (import) — SKIP (expected: no pre-registered manager on fresh stack; passes on warm stack)
- [ ] Full acceptance suite requires staging API fix for `environment_canonical` field (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)