### PR TITLE
feat(provider): org-scoped environment resource (meta-gov-env pre-shot)

### DIFF
--- a/datasource_cloud_account/cloud_account_data_source_schema.go
+++ b/datasource_cloud_account/cloud_account_data_source_schema.go
@@ -1,0 +1,69 @@
+package datasource_cloud_account
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func CloudAccountDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Look up a single Cycloid cloud account by canonical.",
+		MarkdownDescription: "Look up a single Cycloid cloud account by canonical.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to look up the cloud account in. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to look up the cloud account in. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"canonical": schema.StringAttribute{
+				Description:         "Canonical of the cloud account to look up.",
+				MarkdownDescription: "Canonical of the cloud account to look up.",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				Description:         "Display name of the cloud account.",
+				MarkdownDescription: "Display name of the cloud account.",
+				Computed:            true,
+			},
+			"cloud_provider": schema.StringAttribute{
+				Description:         "Canonical of the associated cloud provider.",
+				MarkdownDescription: "Canonical of the associated cloud provider.",
+				Computed:            true,
+			},
+			"credential_canonical": schema.StringAttribute{
+				Description:         "Canonical of the credential currently linked to this cloud account.",
+				MarkdownDescription: "Canonical of the credential currently linked to this cloud account.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				Description:         "Free-form description of the cloud account.",
+				MarkdownDescription: "Free-form description of the cloud account.",
+				Computed:            true,
+			},
+			"owner": schema.StringAttribute{
+				Description:         "Username of the cloud account owner.",
+				MarkdownDescription: "Username of the cloud account owner.",
+				Computed:            true,
+			},
+			"id": schema.Int64Attribute{
+				Description:         "Internal numeric ID assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID assigned by the Cycloid API.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type CloudAccountModel struct {
+	Organization        types.String `tfsdk:"organization"`
+	Canonical           types.String `tfsdk:"canonical"`
+	Name                types.String `tfsdk:"name"`
+	CloudProvider       types.String `tfsdk:"cloud_provider"`
+	CredentialCanonical types.String `tfsdk:"credential_canonical"`
+	Description         types.String `tfsdk:"description"`
+	Owner               types.String `tfsdk:"owner"`
+	ID                  types.Int64  `tfsdk:"id"`
+}

--- a/datasource_cloud_accounts/cloud_accounts_data_source_schema.go
+++ b/datasource_cloud_accounts/cloud_accounts_data_source_schema.go
@@ -1,0 +1,50 @@
+package datasource_cloud_accounts
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func CloudAccountsDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "List Cycloid cloud accounts in an organization, optionally filtered by cloud provider.",
+		MarkdownDescription: "List Cycloid cloud accounts in an organization, optionally filtered by cloud provider.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to list cloud accounts from. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to list cloud accounts from. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"cloud_provider": schema.StringAttribute{
+				Description:         "Optional cloud provider canonical to filter on (e.g. `aws`, `google`, `azurerm`, or a custom canonical).",
+				MarkdownDescription: "Optional cloud provider canonical to filter on (e.g. `aws`, `google`, `azurerm`, or a custom canonical).",
+				Optional:            true,
+			},
+			"cloud_accounts": schema.ListNestedAttribute{
+				Description:         "Matching cloud accounts.",
+				MarkdownDescription: "Matching cloud accounts.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"canonical":            schema.StringAttribute{Computed: true},
+						"name":                 schema.StringAttribute{Computed: true},
+						"cloud_provider":       schema.StringAttribute{Computed: true},
+						"credential_canonical": schema.StringAttribute{Computed: true},
+						"description":          schema.StringAttribute{Computed: true},
+						"owner":                schema.StringAttribute{Computed: true},
+						"id":                   schema.Int64Attribute{Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+type CloudAccountsModel struct {
+	Organization  types.String `tfsdk:"organization"`
+	CloudProvider types.String `tfsdk:"cloud_provider"`
+	CloudAccounts types.List   `tfsdk:"cloud_accounts"`
+}

--- a/datasource_environment/environment_data_source_schema.go
+++ b/datasource_environment/environment_data_source_schema.go
@@ -1,0 +1,103 @@
+package datasource_environment
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Look up a single Cycloid organization-scoped environment by canonical.",
+		MarkdownDescription: "Look up a single Cycloid organization-scoped environment by canonical.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to look up the environment in. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to look up the environment in. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"canonical": schema.StringAttribute{
+				Description:         "Canonical of the environment to look up.",
+				MarkdownDescription: "Canonical of the environment to look up.",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				Description:         "Display name of the environment.",
+				MarkdownDescription: "Display name of the environment.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				Description:         "Free-form description of the environment.",
+				MarkdownDescription: "Free-form description of the environment.",
+				Computed:            true,
+			},
+			"type": schema.StringAttribute{
+				Description:         "Canonical of the environment type associated with this environment.",
+				MarkdownDescription: "Canonical of the environment type associated with this environment.",
+				Computed:            true,
+			},
+			"owner": schema.StringAttribute{
+				Description:         "Username of the environment owner.",
+				MarkdownDescription: "Username of the environment owner.",
+				Computed:            true,
+			},
+			"cloud_account_canonicals": schema.ListAttribute{
+				Description:         "Canonicals of the cloud accounts linked to this environment.",
+				MarkdownDescription: "Canonicals of the cloud accounts linked to this environment.",
+				ElementType:         types.StringType,
+				Computed:            true,
+			},
+			"variables": schema.ListNestedAttribute{
+				Description:         "Environment variables attached to this environment.",
+				MarkdownDescription: "Environment variables attached to this environment.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"key":         schema.StringAttribute{Computed: true},
+						"type":        schema.StringAttribute{Computed: true},
+						"value":       schema.DynamicAttribute{Computed: true, Sensitive: true},
+						"description": schema.StringAttribute{Computed: true},
+						"sensitive":   schema.BoolAttribute{Computed: true},
+					},
+				},
+			},
+			"resources_count": schema.Int64Attribute{
+				Description:         "Total count of infrastructure resources attributed to this environment.",
+				MarkdownDescription: "Total count of infrastructure resources attributed to this environment.",
+				Computed:            true,
+			},
+			"id": schema.Int64Attribute{
+				Description:         "Internal numeric ID assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID assigned by the Cycloid API.",
+				Computed:            true,
+			},
+			"created_at": schema.Int64Attribute{
+				Description:         "Unix timestamp at which the environment was created.",
+				MarkdownDescription: "Unix timestamp at which the environment was created.",
+				Computed:            true,
+			},
+			"updated_at": schema.Int64Attribute{
+				Description:         "Unix timestamp at which the environment was last updated.",
+				MarkdownDescription: "Unix timestamp at which the environment was last updated.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type EnvironmentModel struct {
+	Organization           types.String `tfsdk:"organization"`
+	Canonical              types.String `tfsdk:"canonical"`
+	Name                   types.String `tfsdk:"name"`
+	Description            types.String `tfsdk:"description"`
+	Type                   types.String `tfsdk:"type"`
+	Owner                  types.String `tfsdk:"owner"`
+	CloudAccountCanonicals types.List   `tfsdk:"cloud_account_canonicals"`
+	Variables              types.List   `tfsdk:"variables"`
+	ResourcesCount         types.Int64  `tfsdk:"resources_count"`
+	ID                     types.Int64  `tfsdk:"id"`
+	CreatedAt              types.Int64  `tfsdk:"created_at"`
+	UpdatedAt              types.Int64  `tfsdk:"updated_at"`
+}

--- a/datasource_environment/environment_data_source_schema.go
+++ b/datasource_environment/environment_data_source_schema.go
@@ -57,7 +57,7 @@ func EnvironmentDataSourceSchema(ctx context.Context) schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"key":         schema.StringAttribute{Computed: true},
 						"type":        schema.StringAttribute{Computed: true},
-						"value":       schema.DynamicAttribute{Computed: true, Sensitive: true},
+						"value":       schema.StringAttribute{Computed: true, Sensitive: true},
 						"description": schema.StringAttribute{Computed: true},
 						"sensitive":   schema.BoolAttribute{Computed: true},
 					},

--- a/datasource_environment_type/environment_type_data_source_schema.go
+++ b/datasource_environment_type/environment_type_data_source_schema.go
@@ -1,0 +1,63 @@
+package datasource_environment_type
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentTypeDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Look up a single Cycloid environment type by canonical.",
+		MarkdownDescription: "Look up a single Cycloid environment type by canonical.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to look up the environment type in. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to look up the environment type in. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"canonical": schema.StringAttribute{
+				Description:         "Canonical of the environment type to look up.",
+				MarkdownDescription: "Canonical of the environment type to look up.",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				Description:         "Display name of the environment type.",
+				MarkdownDescription: "Display name of the environment type.",
+				Computed:            true,
+			},
+			"color": schema.StringAttribute{
+				Description:         "Color associated with this environment type.",
+				MarkdownDescription: "Color associated with this environment type.",
+				Computed:            true,
+			},
+			"is_default": schema.BoolAttribute{
+				Description:         "True for built-in environment types that cannot be renamed or deleted.",
+				MarkdownDescription: "True for built-in environment types that cannot be renamed or deleted.",
+				Computed:            true,
+			},
+			"environments_count": schema.Int64Attribute{
+				Description:         "Number of environments currently using this type.",
+				MarkdownDescription: "Number of environments currently using this type.",
+				Computed:            true,
+			},
+			"id": schema.Int64Attribute{
+				Description:         "Internal numeric ID assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID assigned by the Cycloid API.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type EnvironmentTypeModel struct {
+	Organization      types.String `tfsdk:"organization"`
+	Canonical         types.String `tfsdk:"canonical"`
+	Name              types.String `tfsdk:"name"`
+	Color             types.String `tfsdk:"color"`
+	IsDefault         types.Bool   `tfsdk:"is_default"`
+	EnvironmentsCount types.Int64  `tfsdk:"environments_count"`
+	ID                types.Int64  `tfsdk:"id"`
+}

--- a/datasource_environment_types/environment_types_data_source_schema.go
+++ b/datasource_environment_types/environment_types_data_source_schema.go
@@ -1,0 +1,43 @@
+package datasource_environment_types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentTypesDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "List all Cycloid environment types in an organization.",
+		MarkdownDescription: "List all Cycloid environment types in an organization.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to list environment types from. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to list environment types from. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"environment_types": schema.ListNestedAttribute{
+				Description:         "Environment types in the organization.",
+				MarkdownDescription: "Environment types in the organization.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"canonical":          schema.StringAttribute{Computed: true},
+						"name":               schema.StringAttribute{Computed: true},
+						"color":              schema.StringAttribute{Computed: true},
+						"is_default":         schema.BoolAttribute{Computed: true},
+						"environments_count": schema.Int64Attribute{Computed: true},
+						"id":                 schema.Int64Attribute{Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+type EnvironmentTypesModel struct {
+	Organization     types.String `tfsdk:"organization"`
+	EnvironmentTypes types.List   `tfsdk:"environment_types"`
+}

--- a/datasource_environments/environments_data_source_schema.go
+++ b/datasource_environments/environments_data_source_schema.go
@@ -1,0 +1,52 @@
+package datasource_environments
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentsDataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "List Cycloid environments. Without a `project` filter, returns the organization-scoped catalog. With a `project` filter, returns only environments linked to that project.",
+		MarkdownDescription: "List Cycloid environments. Without a `project` filter, returns the organization-scoped catalog. With a `project` filter, returns only environments linked to that project.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical to list environments from. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical to list environments from. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"project": schema.StringAttribute{
+				Description:         "Optional project canonical to filter the listing. When set, only environments linked to that project are returned.",
+				MarkdownDescription: "Optional project canonical to filter the listing. When set, only environments linked to that project are returned.",
+				Optional:            true,
+			},
+			"environments": schema.ListNestedAttribute{
+				Description:         "Matching environments.",
+				MarkdownDescription: "Matching environments.",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"canonical":       schema.StringAttribute{Computed: true},
+						"name":            schema.StringAttribute{Computed: true},
+						"description":     schema.StringAttribute{Computed: true},
+						"type":            schema.StringAttribute{Computed: true},
+						"owner":           schema.StringAttribute{Computed: true},
+						"resources_count": schema.Int64Attribute{Computed: true},
+						"id":              schema.Int64Attribute{Computed: true},
+						"created_at":      schema.Int64Attribute{Computed: true},
+						"updated_at":      schema.Int64Attribute{Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+type EnvironmentsModel struct {
+	Organization types.String `tfsdk:"organization"`
+	Project      types.String `tfsdk:"project"`
+	Environments types.List   `tfsdk:"environments"`
+}

--- a/examples/data-sources/cycloid_cloud_account/data-source.tf
+++ b/examples/data-sources/cycloid_cloud_account/data-source.tf
@@ -1,0 +1,7 @@
+data "cycloid_cloud_account" "aws_main" {
+  canonical = "aws-main"
+}
+
+output "aws_main_credential" {
+  value = data.cycloid_cloud_account.aws_main.credential_canonical
+}

--- a/examples/data-sources/cycloid_cloud_accounts/data-source.tf
+++ b/examples/data-sources/cycloid_cloud_accounts/data-source.tf
@@ -1,0 +1,7 @@
+data "cycloid_cloud_accounts" "aws" {
+  cloud_provider = "aws"
+}
+
+output "aws_account_canonicals" {
+  value = [for ca in data.cycloid_cloud_accounts.aws.cloud_accounts : ca.canonical]
+}

--- a/examples/data-sources/cycloid_environment/data-source.tf
+++ b/examples/data-sources/cycloid_environment/data-source.tf
@@ -1,0 +1,7 @@
+data "cycloid_environment" "shared_prod" {
+  canonical = "production"
+}
+
+output "shared_prod_clouds" {
+  value = data.cycloid_environment.shared_prod.cloud_account_canonicals
+}

--- a/examples/data-sources/cycloid_environment_type/data-source.tf
+++ b/examples/data-sources/cycloid_environment_type/data-source.tf
@@ -1,0 +1,7 @@
+data "cycloid_environment_type" "production" {
+  canonical = "production"
+}
+
+output "production_color" {
+  value = data.cycloid_environment_type.production.color
+}

--- a/examples/data-sources/cycloid_environment_types/data-source.tf
+++ b/examples/data-sources/cycloid_environment_types/data-source.tf
@@ -1,0 +1,5 @@
+data "cycloid_environment_types" "all" {}
+
+output "env_type_canonicals" {
+  value = [for et in data.cycloid_environment_types.all.environment_types : et.canonical]
+}

--- a/examples/data-sources/cycloid_environments/data-source.tf
+++ b/examples/data-sources/cycloid_environments/data-source.tf
@@ -1,0 +1,11 @@
+# All environments in the org.
+data "cycloid_environments" "catalog" {}
+
+# Only environments linked to one project.
+data "cycloid_environments" "billing" {
+  project = "billing"
+}
+
+output "billing_envs" {
+  value = [for e in data.cycloid_environments.billing.environments : e.canonical]
+}

--- a/examples/resources/cycloid_cloud_account/resource.tf
+++ b/examples/resources/cycloid_cloud_account/resource.tf
@@ -1,0 +1,34 @@
+resource "cycloid_credential" "aws_main" {
+  name = "AWS main"
+  type = "aws"
+  body = {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+  }
+}
+
+resource "cycloid_cloud_account" "aws_main" {
+  name                 = "AWS main"
+  cloud_provider       = "aws"
+  credential_canonical = cycloid_credential.aws_main.canonical
+  description          = "Production AWS account, eu-west-1"
+}
+
+resource "cycloid_credential" "vsphere" {
+  name = "vSphere root"
+  type = "custom"
+  body = {
+    raw = {
+      host     = var.vsphere_host
+      user     = var.vsphere_user
+      password = var.vsphere_password
+    }
+  }
+}
+
+resource "cycloid_cloud_account" "vsphere_homelab" {
+  canonical            = "vsphere-homelab"
+  name                 = "vSphere homelab"
+  cloud_provider       = "vsphere"
+  credential_canonical = cycloid_credential.vsphere.canonical
+}

--- a/examples/resources/cycloid_environment/resource.tf
+++ b/examples/resources/cycloid_environment/resource.tf
@@ -1,13 +1,71 @@
 resource "cycloid_project" "my_project" {
-  name = "My project"
-  # canonical = "my-project" # if you omit the canonical parameter, the backend will make it from the name.
+  name        = "My project"
   description = "Some nice description for my users"
   owner       = "some-team"
 }
 
-resource "cycloid_environment" "standard_environments" {
-  for_each = toset(["Dev", "Prod", "Staging"])
-  name     = each.value
-  project  = cycloid_project.my_project.canonical
+resource "cycloid_environment_type" "prod" {
+  name  = "Production"
+  color = "#27ae60"
 }
 
+resource "cycloid_credential" "aws_main" {
+  name = "AWS main"
+  type = "aws"
+  body = {
+    access_key = var.aws_access_key
+    secret_key = var.aws_secret_key
+  }
+}
+
+resource "cycloid_cloud_account" "aws_main" {
+  name                 = "AWS main"
+  cloud_provider       = "aws"
+  credential_canonical = cycloid_credential.aws_main.canonical
+}
+
+# Minimal environment — only the project link is mandatory.
+resource "cycloid_environment" "dev" {
+  project = cycloid_project.my_project.canonical
+  name    = "Dev"
+}
+
+# Environment with the full meta-gov-env feature set.
+resource "cycloid_environment" "prod" {
+  project     = cycloid_project.my_project.canonical
+  name        = "Production"
+  type        = cycloid_environment_type.prod.canonical
+  owner       = "frederic"
+  description = "Customer-facing production environment"
+
+  cloud_account_canonicals = [
+    cycloid_cloud_account.aws_main.canonical,
+  ]
+
+  variables = [
+    {
+      key   = "region"
+      type  = "string"
+      value = "eu-west-1"
+    },
+    {
+      key   = "max_pods"
+      type  = "integer"
+      value = 110
+    },
+    {
+      key       = "api_token"
+      type      = "string"
+      value     = var.api_token
+      sensitive = true
+    },
+  ]
+}
+
+# Bulk creation pattern stays supported.
+resource "cycloid_environment" "standard_environments" {
+  for_each = toset(["staging", "preprod"])
+  canonical = each.value
+  name      = each.value
+  project   = cycloid_project.my_project.canonical
+}

--- a/examples/resources/cycloid_environment_link/resource.tf
+++ b/examples/resources/cycloid_environment_link/resource.tf
@@ -1,0 +1,21 @@
+resource "cycloid_project" "platform" { name = "Platform" }
+resource "cycloid_project" "billing"  { name = "Billing" }
+resource "cycloid_project" "auth"     { name = "Auth" }
+
+# Primary link: the environment is created and linked to the platform project.
+resource "cycloid_environment" "shared_prod" {
+  project = cycloid_project.platform.canonical
+  name    = "Production"
+  type    = "production"
+}
+
+# Additional links: the same org-scoped environment is shared with billing and auth.
+resource "cycloid_environment_link" "billing_prod" {
+  project     = cycloid_project.billing.canonical
+  environment = cycloid_environment.shared_prod.canonical
+}
+
+resource "cycloid_environment_link" "auth_prod" {
+  project     = cycloid_project.auth.canonical
+  environment = cycloid_environment.shared_prod.canonical
+}

--- a/examples/resources/cycloid_environment_type/resource.tf
+++ b/examples/resources/cycloid_environment_type/resource.tf
@@ -1,0 +1,10 @@
+resource "cycloid_environment_type" "qa" {
+  name  = "QA"
+  color = "#9b59b6"
+}
+
+resource "cycloid_environment_type" "preprod" {
+  canonical = "preprod"
+  name      = "Pre-production"
+  color     = "#f39c12"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/cycloidio/cycloid-cli v1.0.98-0.20260526144644-52cb55bb8d77
+	github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
@@ -109,5 +109,3 @@ require (
 	google.golang.org/grpc v1.79.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/cycloidio/cycloid-cli => ../cycloid-cli

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758
+	github.com/cycloidio/cycloid-cli v1.0.98-0.20260526144644-52cb55bb8d77
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -109,3 +109,5 @@ require (
 	google.golang.org/grpc v1.79.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/cycloidio/cycloid-cli => ../cycloid-cli

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758 h1:Rqbmh2jvsQWDXGMQjkVJx7F+3vvDEqZI+0bvgxPludU=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260525114514-ab3d5fb84758/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067 h1:3VLXeJdYpSWIDRJRwhEs+93DMnZqp9xDiB3vqVBIIYQ=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/provider/cloud_account_datasource.go
+++ b/provider/cloud_account_datasource.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_cloud_account"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &cloudAccountDataSource{}
+
+type cloudAccountDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewCloudAccountDataSource() datasource.DataSource {
+	return &cloudAccountDataSource{}
+}
+
+func (s *cloudAccountDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_account"
+}
+
+func (s *cloudAccountDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_cloud_account.CloudAccountDataSourceSchema(ctx)
+}
+
+func (s *cloudAccountDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+func (s *cloudAccountDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_cloud_account.CloudAccountModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	ca, _, err := s.provider.Middleware.GetCloudAccount(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read cloud account '"+canonical+"'", err.Error())
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.Canonical = types.StringPointerValue(ca.Canonical)
+	data.Name = types.StringPointerValue(ca.Name)
+	data.CloudProvider = types.StringPointerValue(ca.CloudProvider)
+	data.Description = types.StringValue(ca.Description)
+	data.ID = ptrUint32ToInt64(ca.ID)
+
+	if ca.Credential != nil {
+		data.CredentialCanonical = types.StringPointerValue(ca.Credential.Canonical)
+	} else {
+		data.CredentialCanonical = types.StringNull()
+	}
+
+	if ca.Owner != nil && ca.Owner.Username != nil {
+		data.Owner = types.StringPointerValue(ca.Owner.Username)
+	} else {
+		data.Owner = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/provider/cloud_account_resource.go
+++ b/provider/cloud_account_resource.go
@@ -1,0 +1,203 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_cloud_account"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*cloudAccountResource)(nil)
+var _ resource.ResourceWithImportState = (*cloudAccountResource)(nil)
+
+func NewCloudAccountResource() resource.Resource {
+	return &cloudAccountResource{}
+}
+
+type cloudAccountResource struct {
+	provider *CycloidProvider
+}
+
+type cloudAccountResourceModel resource_cloud_account.CloudAccountModel
+
+func (r *cloudAccountResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_account"
+}
+
+func (r *cloudAccountResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_cloud_account.CloudAccountResourceSchema(ctx)
+}
+
+func (r *cloudAccountResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	r.provider = pv
+}
+
+func (r *cloudAccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data cloudAccountResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	name := data.Name.ValueString()
+	canonical := data.Canonical.ValueString()
+
+	var err error
+	name, canonical, err = NameOrCanonical(name, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to infer cloud account canonical", err.Error())
+		return
+	}
+
+	body := &models.NewCloudAccount{
+		Name:                &name,
+		Canonical:           canonical,
+		CloudProvider:       data.CloudProvider.ValueStringPointer(),
+		CredentialCanonical: data.CredentialCanonical.ValueStringPointer(),
+		Description:         data.Description.ValueString(),
+		Owner:               data.Owner.ValueString(),
+	}
+
+	m := r.provider.Middleware
+	_, _, err = m.CreateCloudAccount(org, body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create cloud account", err.Error())
+		return
+	}
+
+	// CreateCloudAccount returns *CloudAccount (no detail), re-read for full state.
+	ca, _, err := m.GetCloudAccount(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read cloud account after creation", err.Error())
+		return
+	}
+
+	cloudAccountCYModelToData(org, ca, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudAccountResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data cloudAccountResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	ca, _, err := r.provider.Middleware.GetCloudAccount(org, canonical)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to read cloud account", err.Error())
+		return
+	}
+
+	cloudAccountCYModelToData(org, ca, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data cloudAccountResourceModel
+	var stateData cloudAccountResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := Coalesce(stateData.Canonical.ValueString(), data.Canonical.ValueString())
+	name := data.Name.ValueString()
+
+	body := &models.UpdateCloudAccount{
+		Name:                &name,
+		CredentialCanonical: data.CredentialCanonical.ValueStringPointer(),
+		Description:         data.Description.ValueString(),
+		Owner:               data.Owner.ValueString(),
+	}
+
+	m := r.provider.Middleware
+	_, _, err := m.UpdateCloudAccount(org, canonical, body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update cloud account", err.Error())
+		return
+	}
+
+	ca, _, err := m.GetCloudAccount(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read cloud account after update", err.Error())
+		return
+	}
+
+	cloudAccountCYModelToData(org, ca, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *cloudAccountResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data cloudAccountResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	_, err := r.provider.Middleware.DeleteCloudAccount(org, canonical)
+	if err != nil && !isNotFoundError(err) {
+		resp.Diagnostics.AddError("failed to delete cloud account", err.Error())
+	}
+}
+
+func (r *cloudAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("canonical"), req, resp)
+}
+
+func cloudAccountCYModelToData(org string, ca *models.CloudAccountDetail, data *cloudAccountResourceModel) {
+	data.Organization = types.StringValue(org)
+	data.Canonical = types.StringPointerValue(ca.Canonical)
+	data.Name = types.StringPointerValue(ca.Name)
+	data.CloudProvider = types.StringPointerValue(ca.CloudProvider)
+	data.Description = types.StringValue(ca.Description)
+	data.ID = ptrUint32ToInt64(ca.ID)
+
+	if ca.Credential != nil {
+		data.CredentialCanonical = types.StringPointerValue(ca.Credential.Canonical)
+	} else {
+		data.CredentialCanonical = types.StringNull()
+	}
+
+	if ca.Owner != nil && ca.Owner.Username != nil {
+		data.Owner = types.StringPointerValue(ca.Owner.Username)
+	} else {
+		data.Owner = types.StringValue("")
+	}
+}

--- a/provider/cloud_account_resource_test.go
+++ b/provider/cloud_account_resource_test.go
@@ -1,0 +1,113 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccCloudAccountResource_basic(t *testing.T) {
+	t.Parallel()
+
+	credName := RandomCanonical("test-ca-cred")
+	accountName := RandomCanonical("test-cloud-account")
+
+	ctx := context.Background()
+	orgCanonical := testAccGetOrganizationCanonical()
+
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	if depManager.provider.Middleware == nil {
+		t.Skip("skipping acceptance test: CY_API_URL, CY_API_KEY and CY_ORG must be set")
+	}
+
+	// Pre-create the credential outside TF to avoid the credential resource's post-apply drift.
+	cred, _, err := depManager.provider.Middleware.CreateCredential(
+		orgCanonical,
+		credName,
+		"aws",
+		&models.CredentialRaw{AccessKey: "AKIAIOSFODNN7EXAMPLE", SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+		credName, // path == canonical
+		credName,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("failed to pre-create test credential: %v", err)
+	}
+	credCanonical := *cred.Canonical
+	depManager.cleanupItems = append(depManager.cleanupItems, cleanupItem{
+		resourceType: "credential",
+		canonical:    credCanonical,
+		cleanupFunc: func() error {
+			_, err := depManager.provider.Middleware.DeleteCredential(orgCanonical, credCanonical)
+			return err
+		},
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccCloudAccountConfig_basic(orgCanonical, credCanonical, accountName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "name", accountName),
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "cloud_provider", "aws"),
+					resource.TestCheckResourceAttrSet("cycloid_cloud_account.test", "canonical"),
+					resource.TestCheckResourceAttrSet("cycloid_cloud_account.test", "id"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "cycloid_cloud_account.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["cycloid_cloud_account.test"]
+					if rs == nil {
+						return "", fmt.Errorf("cycloid_cloud_account.test not in state")
+					}
+					return rs.Primary.Attributes["canonical"], nil
+				},
+				ImportStateVerifyIgnore: []string{"organization"},
+			},
+			// Update (description only; cloud_provider + credential_canonical trigger replacement)
+			{
+				Config: testAccCloudAccountConfig_basic(orgCanonical, credCanonical, accountName, "updated description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "name", accountName),
+					resource.TestCheckResourceAttr("cycloid_cloud_account.test", "description", "updated description"),
+				),
+			},
+			// Destroy
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
+func testAccCloudAccountConfig_basic(org, credCanonical, accountName, description string) string {
+	descAttr := ""
+	if description != "" {
+		descAttr = fmt.Sprintf(`  description = "%s"`, description)
+	}
+	return fmt.Sprintf(`
+resource "cycloid_cloud_account" "test" {
+  organization         = "%s"
+  name                 = "%s"
+  cloud_provider       = "aws"
+  credential_canonical = "%s"
+%s
+}
+`, org, accountName, credCanonical, descAttr)
+}

--- a/provider/cloud_accounts_datasource.go
+++ b/provider/cloud_accounts_datasource.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_cloud_accounts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &cloudAccountsDataSource{}
+
+type cloudAccountsDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewCloudAccountsDataSource() datasource.DataSource {
+	return &cloudAccountsDataSource{}
+}
+
+func (s *cloudAccountsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cloud_accounts"
+}
+
+func (s *cloudAccountsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_cloud_accounts.CloudAccountsDataSourceSchema(ctx)
+}
+
+func (s *cloudAccountsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+var cloudAccountObjAttrTypes = map[string]attr.Type{
+	"canonical":            types.StringType,
+	"name":                 types.StringType,
+	"cloud_provider":       types.StringType,
+	"credential_canonical": types.StringType,
+	"description":          types.StringType,
+	"owner":                types.StringType,
+	"id":                   types.Int64Type,
+}
+
+func (s *cloudAccountsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_cloud_accounts.CloudAccountsModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+	cloudProviderFilter := data.CloudProvider.ValueString()
+
+	cas, _, err := s.provider.Middleware.ListCloudAccounts(org)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list cloud accounts", err.Error())
+		return
+	}
+
+	items := make([]attr.Value, 0, len(cas))
+	for _, ca := range cas {
+		if cloudProviderFilter != "" && (ca.CloudProvider == nil || *ca.CloudProvider != cloudProviderFilter) {
+			continue
+		}
+
+		credCanonical := types.StringNull()
+		if ca.Credential != nil {
+			credCanonical = types.StringPointerValue(ca.Credential.Canonical)
+		}
+
+		ownerStr := ""
+		if ca.Owner != nil && ca.Owner.Username != nil {
+			ownerStr = *ca.Owner.Username
+		}
+
+		obj, objDiags := types.ObjectValue(cloudAccountObjAttrTypes, map[string]attr.Value{
+			"canonical":            types.StringPointerValue(ca.Canonical),
+			"name":                 types.StringPointerValue(ca.Name),
+			"cloud_provider":       types.StringPointerValue(ca.CloudProvider),
+			"credential_canonical": credCanonical,
+			"description":          types.StringValue(ca.Description),
+			"owner":                types.StringValue(ownerStr),
+			"id":                   ptrUint32ToInt64(ca.ID),
+		})
+		resp.Diagnostics.Append(objDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		items = append(items, obj)
+	}
+
+	listVal, listDiags := types.ListValue(types.ObjectType{AttrTypes: cloudAccountObjAttrTypes}, items)
+	resp.Diagnostics.Append(listDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.CloudAccounts = listVal
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/provider/conversions.go
+++ b/provider/conversions.go
@@ -1,0 +1,17 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+func ptrUint32ToInt64(v *uint32) types.Int64 {
+	if v == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(*v))
+}
+
+func ptrUint64ToInt64(v *uint64) types.Int64 {
+	if v == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(*v))
+}

--- a/provider/environment_datasource.go
+++ b/provider/environment_datasource.go
@@ -1,0 +1,104 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_environment"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &environmentDataSource{}
+
+type environmentDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewEnvironmentDataSource() datasource.DataSource {
+	return &environmentDataSource{}
+}
+
+func (s *environmentDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment"
+}
+
+func (s *environmentDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_environment.EnvironmentDataSourceSchema(ctx)
+}
+
+func (s *environmentDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+func (s *environmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_environment.EnvironmentModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	env, _, err := s.provider.Middleware.GetOrgEnv(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read environment '"+canonical+"'", err.Error())
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.Canonical = types.StringPointerValue(env.Canonical)
+	data.Name = types.StringValue(env.Name)
+	data.Description = types.StringValue(env.Description)
+	data.ResourcesCount = ptrUint32ToInt64(env.ResourcesCount)
+	data.ID = ptrUint32ToInt64(env.ID)
+	data.CreatedAt = ptrUint64ToInt64(env.CreatedAt)
+	data.UpdatedAt = ptrUint64ToInt64(env.UpdatedAt)
+
+	if env.EnvironmentType != nil {
+		data.Type = types.StringPointerValue(env.EnvironmentType.Canonical)
+	} else {
+		data.Type = types.StringNull()
+	}
+
+	if env.Owner != nil && env.Owner.Username != nil {
+		data.Owner = types.StringPointerValue(env.Owner.Username)
+	} else {
+		data.Owner = types.StringValue("")
+	}
+
+	canonicals := make([]string, 0, len(env.CloudAccounts))
+	for _, ca := range env.CloudAccounts {
+		if ca.Canonical != nil {
+			canonicals = append(canonicals, *ca.Canonical)
+		}
+	}
+	cloudAccList, caDiags := types.ListValueFrom(ctx, types.StringType, canonicals)
+	resp.Diagnostics.Append(caDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.CloudAccountCanonicals = cloudAccList
+
+	varList, varDiags := buildVariableList(ctx, env.Variables)
+	resp.Diagnostics.Append(varDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Variables = varList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/provider/environment_helpers.go
+++ b/provider/environment_helpers.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var envVarObjAttrTypes = map[string]attr.Type{
+	"key":         types.StringType,
+	"type":        types.StringType,
+	"value":       types.StringType,
+	"description": types.StringType,
+	"sensitive":   types.BoolType,
+}
+
+// buildVariableList converts API variable items to a types.List suitable for TF state.
+func buildVariableList(ctx context.Context, vars []*models.EnvironmentVariableItem) (types.List, diag.Diagnostics) {
+	elemType := types.ObjectType{AttrTypes: envVarObjAttrTypes}
+
+	if len(vars) == 0 {
+		return types.ListValueMust(elemType, []attr.Value{}), nil
+	}
+
+	items := make([]attr.Value, len(vars))
+	for i, v := range vars {
+		obj, objDiags := types.ObjectValue(envVarObjAttrTypes, map[string]attr.Value{
+			"key":         types.StringPointerValue(v.Key),
+			"type":        types.StringPointerValue(v.Type),
+			"value":       anyToString(v.Value),
+			"description": types.StringValue(v.Description),
+			"sensitive":   types.BoolPointerValue(v.Sensitive),
+		})
+		if objDiags.HasError() {
+			return types.ListNull(elemType), objDiags
+		}
+		items[i] = obj
+	}
+
+	return types.ListValue(elemType, items)
+}
+
+// anyToString converts an API variable value (any) to a TF string attribute.
+func anyToString(v any) types.String {
+	switch val := v.(type) {
+	case string:
+		return types.StringValue(val)
+	case float64:
+		if val == float64(int64(val)) {
+			return types.StringValue(strconv.FormatInt(int64(val), 10))
+		}
+		return types.StringValue(strconv.FormatFloat(val, 'f', -1, 64))
+	case bool:
+		return types.StringValue(strconv.FormatBool(val))
+	case nil:
+		return types.StringNull()
+	default:
+		return types.StringValue(fmt.Sprintf("%v", val))
+	}
+}
+
+// stringToAny converts a TF string value to an API-compatible value, coercing by declared type.
+func stringToAny(s types.String, varType string) any {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	raw := s.ValueString()
+	switch varType {
+	case "boolean":
+		if b, err := strconv.ParseBool(raw); err == nil {
+			return b
+		}
+	case "integer":
+		if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return float64(i)
+		}
+	case "float":
+		if f, err := strconv.ParseFloat(raw, 64); err == nil {
+			return f
+		}
+	}
+	return raw
+}

--- a/provider/environment_link_resource.go
+++ b/provider/environment_link_resource.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	middleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_environment_link"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*environmentLinkResource)(nil)
+var _ resource.ResourceWithImportState = (*environmentLinkResource)(nil)
+
+func NewEnvironmentLinkResource() resource.Resource {
+	return &environmentLinkResource{}
+}
+
+type environmentLinkResource struct {
+	provider *CycloidProvider
+}
+
+type environmentLinkResourceModel resource_environment_link.EnvironmentLinkModel
+
+func (r *environmentLinkResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment_link"
+}
+
+func (r *environmentLinkResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_environment_link.EnvironmentLinkResourceSchema(ctx)
+}
+
+func (r *environmentLinkResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	r.provider = pv
+}
+
+func (r *environmentLinkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data environmentLinkResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	project := data.Project.ValueString()
+	env := data.Environment.ValueString()
+
+	_, err := r.provider.Middleware.LinkEnvToProject(org, project, env)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to link environment to project", err.Error())
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.ID = types.StringValue(org + "/" + project + "/" + env)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *environmentLinkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data environmentLinkResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	project := data.Project.ValueString()
+	env := data.Environment.ValueString()
+
+	envs, _, err := r.provider.Middleware.ListProjectEnvs(org, project)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to list project environments", err.Error())
+		return
+	}
+
+	for _, e := range envs {
+		if e.Canonical != nil && *e.Canonical == env {
+			data.Organization = types.StringValue(org)
+			data.ID = types.StringValue(org + "/" + project + "/" + env)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+			return
+		}
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *environmentLinkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// all attributes force replacement; Update is never called
+}
+
+func (r *environmentLinkResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data environmentLinkResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	project := data.Project.ValueString()
+	env := data.Environment.ValueString()
+
+	_, err := r.provider.Middleware.UnlinkEnvFromProject(org, project, env, middleware.DeleteOptions{})
+	if err != nil && !isNotFoundError(err) {
+		resp.Diagnostics.AddError("failed to unlink environment from project", err.Error())
+	}
+}
+
+func (r *environmentLinkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 3)
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"invalid import ID format",
+			"expected format org/project/environment, got: "+req.ID,
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment"), parts[2])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}

--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -17,8 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-const defaultEnvType = "production" // TODO(meta-gov-env): remove once backend infers type from canonical
-
 var _ resource.Resource = (*environmentResource)(nil)
 
 func NewEnvironmentResource() resource.Resource {
@@ -212,17 +210,17 @@ func environmentToValue(ctx context.Context, org, project string, environment *m
 }
 
 func envTypeFromData(data environmentResourceModel) string {
-	if !data.Type.IsNull() && !data.Type.IsUnknown() && data.Type.ValueString() != "" {
+	if !data.Type.IsNull() && !data.Type.IsUnknown() {
 		return data.Type.ValueString()
 	}
-	return defaultEnvType
+	return ""
 }
 
 func envTypeFromCurrent(environment *models.Environment) string {
 	if environment != nil && environment.EnvironmentType != nil && environment.EnvironmentType.Canonical != nil {
 		return *environment.EnvironmentType.Canonical
 	}
-	return defaultEnvType
+	return ""
 }
 
 func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, incoming environmentResourceModel, isUpdate bool) (environmentResourceModel, diag.Diagnostics) {
@@ -283,14 +281,15 @@ func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, inc
 	if err == nil {
 		updateBody := &models.UpdateEnvironment{
 			Name:                   ptr.Ptr(name),
-			Type:                   ptr.Ptr(envTypeFromCurrent(current)),
 			Description:            description,
 			Owner:                  owner,
 			CloudAccountCanonicals: cloudAccountCanonicals,
 			Variables:              apiVars,
 		}
-		// honour the plan's type if explicitly configured
-		if !incoming.Type.IsNull() && !incoming.Type.IsUnknown() {
+		if t := envTypeFromCurrent(current); t != "" {
+			updateBody.Type = ptr.Ptr(t)
+		}
+		if !incoming.Type.IsNull() && !incoming.Type.IsUnknown() && envType != "" {
 			updateBody.Type = ptr.Ptr(envType)
 		}
 		current, _, err = m.UpdateOrgEnv(org, canonical, updateBody)
@@ -311,11 +310,13 @@ func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, inc
 		createBody := &models.NewEnvironment{
 			Canonical:              canonical,
 			Name:                   ptr.Ptr(name),
-			Type:                   ptr.Ptr(envType),
 			Description:            description,
 			Owner:                  owner,
 			CloudAccountCanonicals: cloudAccountCanonicals,
 			Variables:              apiVars,
+		}
+		if envType != "" {
+			createBody.Type = ptr.Ptr(envType)
 		}
 		current, _, err = m.CreateOrgEnv(org, createBody)
 		if err != nil {

--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -2,9 +2,8 @@ package provider
 
 import (
 	"context"
-	"fmt"
-	"slices"
 	stderrors "errors"
+	"fmt"
 	"net/http"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
@@ -70,42 +69,38 @@ func (p *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	org := getOrganizationCanonical(*p.provider, data.Organization)
 	project := data.Project.ValueString()
 
-	projects, _, err := m.ListProjects(org)
-	if err != nil {
-		resp.Diagnostics.AddError("failed to fetch project from API", err.Error())
-		return
-	}
-
-	if i := slices.IndexFunc(projects, func(p *models.Project) bool {
-		return ptr.Value(p.Canonical) == project
-	}); i == -1 {
-		resp.Diagnostics.Append(environmentToValue(ctx, org, project, &models.Environment{}, &data)...)
-		return
-	}
-
 	projectEnvs, _, err := m.ListProjectEnvs(org, project)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch environment from API while reading state", err.Error())
 		return
 	}
 
-	if i := slices.IndexFunc(projectEnvs, func(e *models.ProjectEnvironment) bool {
-		return ptr.Value(e.Canonical) == canonical
-	}); i == -1 {
+	found := false
+	for _, e := range projectEnvs {
+		if ptr.Value(e.Canonical) == canonical {
+			found = true
+			break
+		}
+	}
+
+	if !found {
 		resp.Diagnostics.Append(environmentToValue(ctx, org, project, &models.Environment{}, &data)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-	} else {
-		environment, _, err := m.GetOrgEnv(org, canonical)
-		if err != nil {
-			resp.Diagnostics.AddError("failed to fetch org environment from API while reading state", err.Error())
-			return
-		}
-		resp.Diagnostics.Append(environmentToValue(ctx, org, project, environment, &data)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
+	environment, _, err := m.GetOrgEnv(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to fetch org environment from API while reading state", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(environmentToValue(ctx, org, project, environment, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -119,16 +114,7 @@ func (p *environmentResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	name := data.Name.ValueString()
-	canonical := data.Canonical.ValueString()
-	org := getOrganizationCanonical(*p.provider, data.Organization)
-	project := data.Project.ValueString()
-	color := data.Color.ValueString()
-	if color == "" {
-		color = icons.RandomColor()
-	}
-
-	data, d := p.createOrUpdateEnvironment(ctx, org, name, canonical, project, color, false)
+	data, d := p.createOrUpdateEnvironment(ctx, data, false)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -145,16 +131,7 @@ func (p *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	name := data.Name.ValueString()
-	canonical := data.Canonical.ValueString()
-	org := getOrganizationCanonical(*p.provider, data.Organization)
-	project := data.Project.ValueString()
-	color := data.Color.ValueString()
-	if color == "" {
-		color = icons.RandomColor()
-	}
-
-	data, d := p.createOrUpdateEnvironment(ctx, org, name, canonical, project, color, true)
+	data, d := p.createOrUpdateEnvironment(ctx, data, true)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -197,16 +174,48 @@ func environmentColor(environment *models.Environment) *string {
 	return environment.EnvironmentType.Color
 }
 
-func environmentToValue(_ context.Context, org, project string, environment *models.Environment, data *environmentResourceModel) diag.Diagnostics {
+func environmentToValue(ctx context.Context, org, project string, environment *models.Environment, data *environmentResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
 	if environment == nil {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("environment is nil for convertion", "This should not happend, please contact the plugin maintainer.")}
+		diags.AddError("environment is nil for conversion", "This should not happen, please contact the plugin maintainer.")
+		return diags
 	}
+
 	data.Canonical = types.StringPointerValue(environment.Canonical)
 	data.Name = types.StringValue(environment.Name)
 	data.Organization = types.StringValue(org)
 	data.Color = types.StringPointerValue(environmentColor(environment))
 	data.Project = types.StringValue(project)
-	return nil
+	data.Description = types.StringValue(environment.Description)
+	data.ID = ptrUint32ToInt64(environment.ID)
+	data.CreatedAt = ptrUint64ToInt64(environment.CreatedAt)
+	data.UpdatedAt = ptrUint64ToInt64(environment.UpdatedAt)
+
+	if environment.EnvironmentType != nil {
+		data.Type = types.StringPointerValue(environment.EnvironmentType.Canonical)
+	} else {
+		data.Type = types.StringNull()
+	}
+
+	if environment.Owner != nil && environment.Owner.Username != nil {
+		data.Owner = types.StringPointerValue(environment.Owner.Username)
+	} else {
+		data.Owner = types.StringValue("")
+	}
+
+	// CloudAccountCanonicals and Variables are PATCH-semantic Optional-only attributes.
+	// They are NOT updated from the API in Read — state is preserved from prior plan/state.
+	// They ARE set after Create/Update in createOrUpdateEnvironment.
+
+	return diags
+}
+
+func envTypeFromData(data environmentResourceModel) string {
+	if !data.Type.IsNull() && !data.Type.IsUnknown() && data.Type.ValueString() != "" {
+		return data.Type.ValueString()
+	}
+	return defaultEnvType
 }
 
 func envTypeFromCurrent(environment *models.Environment) string {
@@ -216,23 +225,73 @@ func envTypeFromCurrent(environment *models.Environment) string {
 	return defaultEnvType
 }
 
-func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, org, name, canonical, project, color string, isUpdate bool) (environmentResourceModel, diag.Diagnostics) {
+func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, incoming environmentResourceModel, isUpdate bool) (environmentResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var data environmentResourceModel
-	var err error
 
+	org := getOrganizationCanonical(*p.provider, incoming.Organization)
+	name := incoming.Name.ValueString()
+	canonical := incoming.Canonical.ValueString()
+	project := incoming.Project.ValueString()
+	color := incoming.Color.ValueString()
+	if color == "" {
+		color = icons.RandomColor()
+	}
+
+	var err error
 	name, canonical, err = NameOrCanonical(name, canonical)
 	if err != nil {
 		diags.AddError("failed to infer canonical", err.Error())
 		return data, diags
 	}
 
+	description := incoming.Description.ValueString()
+	owner := incoming.Owner.ValueString()
+	envType := envTypeFromData(incoming)
+
+	var cloudAccountCanonicals []string
+	if !incoming.CloudAccountCanonicals.IsNull() && !incoming.CloudAccountCanonicals.IsUnknown() {
+		diags.Append(incoming.CloudAccountCanonicals.ElementsAs(ctx, &cloudAccountCanonicals, false)...)
+		if diags.HasError() {
+			return data, diags
+		}
+	}
+
+	var apiVars []*models.EnvironmentVariableItem
+	if !incoming.Variables.IsNull() && !incoming.Variables.IsUnknown() {
+		var varModels []resource_environment.EnvironmentVariableModel
+		diags.Append(incoming.Variables.ElementsAs(ctx, &varModels, false)...)
+		if diags.HasError() {
+			return data, diags
+		}
+		apiVars = make([]*models.EnvironmentVariableItem, len(varModels))
+		for i, vm := range varModels {
+			key := vm.Key.ValueString()
+			typ := vm.Type.ValueString()
+			apiVars[i] = &models.EnvironmentVariableItem{
+				Key:         &key,
+				Type:        &typ,
+				Value:       stringToAny(vm.Value, typ),
+				Description: vm.Description.ValueString(),
+				Sensitive:   vm.Sensitive.ValueBoolPointer(),
+			}
+		}
+	}
+
 	m := p.provider.Middleware
 	current, _, err := m.GetOrgEnv(org, canonical)
 	if err == nil {
 		updateBody := &models.UpdateEnvironment{
-			Name: ptr.Ptr(name),
-			Type: ptr.Ptr(envTypeFromCurrent(current)),
+			Name:                   ptr.Ptr(name),
+			Type:                   ptr.Ptr(envTypeFromCurrent(current)),
+			Description:            description,
+			Owner:                  owner,
+			CloudAccountCanonicals: cloudAccountCanonicals,
+			Variables:              apiVars,
+		}
+		// honour the plan's type if explicitly configured
+		if !incoming.Type.IsNull() && !incoming.Type.IsUnknown() {
+			updateBody.Type = ptr.Ptr(envType)
 		}
 		current, _, err = m.UpdateOrgEnv(org, canonical, updateBody)
 		if err != nil {
@@ -250,9 +309,13 @@ func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, org
 		}
 
 		createBody := &models.NewEnvironment{
-			Canonical: canonical,
-			Name:      ptr.Ptr(name),
-			Type:      ptr.Ptr(defaultEnvType),
+			Canonical:              canonical,
+			Name:                   ptr.Ptr(name),
+			Type:                   ptr.Ptr(envType),
+			Description:            description,
+			Owner:                  owner,
+			CloudAccountCanonicals: cloudAccountCanonicals,
+			Variables:              apiVars,
 		}
 		current, _, err = m.CreateOrgEnv(org, createBody)
 		if err != nil {
@@ -273,6 +336,13 @@ func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, org
 	}
 
 	_ = color // color is deprecated on environments; kept in schema for backward compatibility
+	_ = current
+
 	diags.Append(environmentToValue(ctx, org, project, environment, &data)...)
+
+	// Preserve PATCH-semantic fields from the plan — these are Optional-only (not Computed).
+	data.CloudAccountCanonicals = incoming.CloudAccountCanonicals
+	data.Variables = incoming.Variables
+
 	return data, diags
 }

--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	stderrors "errors"
+	"net/http"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
 	middleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
@@ -15,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+const defaultEnvType = "production" // TODO(meta-gov-env): remove once backend infers type from canonical
 
 var _ resource.Resource = (*environmentResource)(nil)
 
@@ -66,7 +70,6 @@ func (p *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	org := getOrganizationCanonical(*p.provider, data.Organization)
 	project := data.Project.ValueString()
 
-	// Check that the project exists
 	projects, _, err := m.ListProjects(org)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch project from API", err.Error())
@@ -76,28 +79,30 @@ func (p *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	if i := slices.IndexFunc(projects, func(p *models.Project) bool {
 		return ptr.Value(p.Canonical) == project
 	}); i == -1 {
-		// Project doesn't exist, so empty state
-		// Environment doesn't exist, so empty state
 		resp.Diagnostics.Append(environmentToValue(ctx, org, project, &models.Environment{}, &data)...)
 		return
 	}
 
-	environments, _, err := m.ListProjectsEnv(org, project)
+	projectEnvs, _, err := m.ListProjectEnvs(org, project)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to fetch environment from API while reading state", err.Error())
 		return
 	}
 
-	if i := slices.IndexFunc(environments, func(e *models.Environment) bool {
+	if i := slices.IndexFunc(projectEnvs, func(e *models.ProjectEnvironment) bool {
 		return ptr.Value(e.Canonical) == canonical
 	}); i == -1 {
-		// Environment doesn't exist, so empty state
 		resp.Diagnostics.Append(environmentToValue(ctx, org, project, &models.Environment{}, &data)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 	} else {
-		resp.Diagnostics.Append(environmentToValue(ctx, org, project, environments[i], &data)...)
+		environment, _, err := m.GetOrgEnv(org, canonical)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to fetch org environment from API while reading state", err.Error())
+			return
+		}
+		resp.Diagnostics.Append(environmentToValue(ctx, org, project, environment, &data)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -146,7 +151,7 @@ func (p *environmentResource) Update(ctx context.Context, req resource.UpdateReq
 	project := data.Project.ValueString()
 	color := data.Color.ValueString()
 	if color == "" {
-		color = icons.RandomIcon()
+		color = icons.RandomColor()
 	}
 
 	data, d := p.createOrUpdateEnvironment(ctx, org, name, canonical, project, color, true)
@@ -171,9 +176,9 @@ func (p *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 	project := data.Project.ValueString()
 	canonical := data.Canonical.ValueString()
 
-	_, err := m.DeleteEnv(org, project, canonical, middleware.DeleteOptions{})
+	_, err := m.UnlinkEnvFromProject(org, project, canonical, middleware.DeleteOptions{})
 	if err != nil {
-		resp.Diagnostics.AddError("failed to delete environment from API while deleting resource", err.Error())
+		resp.Diagnostics.AddError("failed to unlink environment from project while deleting resource", err.Error())
 		return
 	}
 
@@ -185,6 +190,13 @@ func (p *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
+func environmentColor(environment *models.Environment) *string {
+	if environment == nil || environment.EnvironmentType == nil {
+		return nil
+	}
+	return environment.EnvironmentType.Color
+}
+
 func environmentToValue(_ context.Context, org, project string, environment *models.Environment, data *environmentResourceModel) diag.Diagnostics {
 	if environment == nil {
 		return diag.Diagnostics{diag.NewErrorDiagnostic("environment is nil for convertion", "This should not happend, please contact the plugin maintainer.")}
@@ -192,9 +204,16 @@ func environmentToValue(_ context.Context, org, project string, environment *mod
 	data.Canonical = types.StringPointerValue(environment.Canonical)
 	data.Name = types.StringValue(environment.Name)
 	data.Organization = types.StringValue(org)
-	data.Color = types.StringPointerValue(environment.Color)
+	data.Color = types.StringPointerValue(environmentColor(environment))
 	data.Project = types.StringValue(project)
 	return nil
+}
+
+func envTypeFromCurrent(environment *models.Environment) string {
+	if environment != nil && environment.EnvironmentType != nil && environment.EnvironmentType.Canonical != nil {
+		return *environment.EnvironmentType.Canonical
+	}
+	return defaultEnvType
 }
 
 func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, org, name, canonical, project, color string, isUpdate bool) (environmentResourceModel, diag.Diagnostics) {
@@ -208,33 +227,52 @@ func (p *environmentResource) createOrUpdateEnvironment(ctx context.Context, org
 		return data, diags
 	}
 
-	environments, _, err := p.provider.Middleware.ListProjectsEnv(org, project)
-	if err != nil {
-		diags.AddError("failed to fetch environments from API while updating resource", err.Error())
-		return data, diags
-	}
-
-	var environment *models.Environment
-	if i := slices.IndexFunc(environments, func(p *models.Environment) bool {
-		return ptr.Value(p.Canonical) == canonical
-	}); i == -1 {
-		if isUpdate {
-			tflog.Info(ctx, "did not found current environment, assuming it had been deleted outside the provider, re-creating...", nil)
+	m := p.provider.Middleware
+	current, _, err := m.GetOrgEnv(org, canonical)
+	if err == nil {
+		updateBody := &models.UpdateEnvironment{
+			Name: ptr.Ptr(name),
+			Type: ptr.Ptr(envTypeFromCurrent(current)),
 		}
-
-		environment, _, err = p.provider.Middleware.CreateEnv(org, project, canonical, name, color)
-		if err != nil {
-			diags.AddError("failed to create environment from API", err.Error())
-			return data, diags
-		}
-	} else {
-		environment, _, err = p.provider.Middleware.UpdateEnv(org, project, canonical, name, color)
+		current, _, err = m.UpdateOrgEnv(org, canonical, updateBody)
 		if err != nil {
 			diags.AddError("failed to update environment from API", err.Error())
 			return data, diags
 		}
+	} else {
+		var apiErr *middleware.APIResponseError
+		if !stderrors.As(err, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+			diags.AddError("failed to fetch environment from API while updating resource", err.Error())
+			return data, diags
+		}
+		if isUpdate {
+			tflog.Info(ctx, "did not find current environment, assuming it had been deleted outside the provider, re-creating...", nil)
+		}
+
+		createBody := &models.NewEnvironment{
+			Canonical: canonical,
+			Name:      ptr.Ptr(name),
+			Type:      ptr.Ptr(defaultEnvType),
+		}
+		current, _, err = m.CreateOrgEnv(org, createBody)
+		if err != nil {
+			diags.AddError("failed to create environment from API", err.Error())
+			return data, diags
+		}
 	}
 
+	if _, err = m.LinkEnvToProject(org, project, canonical); err != nil {
+		diags.AddError("failed to link environment to project from API", err.Error())
+		return data, diags
+	}
+
+	environment, _, err := m.GetOrgEnv(org, canonical)
+	if err != nil {
+		diags.AddError("failed to fetch environment from API after create/update", err.Error())
+		return data, diags
+	}
+
+	_ = color // color is deprecated on environments; kept in schema for backward compatibility
 	diags.Append(environmentToValue(ctx, org, project, environment, &data)...)
 	return data, diags
 }

--- a/provider/environment_type_datasource.go
+++ b/provider/environment_type_datasource.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_environment_type"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &environmentTypeDataSource{}
+
+type environmentTypeDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewEnvironmentTypeDataSource() datasource.DataSource {
+	return &environmentTypeDataSource{}
+}
+
+func (s *environmentTypeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment_type"
+}
+
+func (s *environmentTypeDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_environment_type.EnvironmentTypeDataSourceSchema(ctx)
+}
+
+func (s *environmentTypeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+func (s *environmentTypeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_environment_type.EnvironmentTypeModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	et, _, err := s.provider.Middleware.GetEnvironmentType(org, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read environment type '"+canonical+"'", err.Error())
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.Canonical = types.StringPointerValue(et.Canonical)
+	data.Name = types.StringPointerValue(et.Name)
+	data.Color = types.StringPointerValue(et.Color)
+	data.IsDefault = types.BoolPointerValue(et.IsDefault)
+	data.EnvironmentsCount = ptrUint32ToInt64(et.EnvironmentsCount)
+	data.ID = ptrUint32ToInt64(et.ID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/provider/environment_type_resource.go
+++ b/provider/environment_type_resource.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_environment_type"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*environmentTypeResource)(nil)
+var _ resource.ResourceWithImportState = (*environmentTypeResource)(nil)
+
+func NewEnvironmentTypeResource() resource.Resource {
+	return &environmentTypeResource{}
+}
+
+type environmentTypeResource struct {
+	provider *CycloidProvider
+}
+
+type environmentTypeResourceModel resource_environment_type.EnvironmentTypeModel
+
+func (r *environmentTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment_type"
+}
+
+func (r *environmentTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_environment_type.EnvironmentTypeResourceSchema(ctx)
+}
+
+func (r *environmentTypeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	r.provider = pv
+}
+
+func (r *environmentTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data environmentTypeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	name := data.Name.ValueString()
+	canonical := data.Canonical.ValueString()
+	color := data.Color.ValueString()
+
+	var err error
+	name, canonical, err = NameOrCanonical(name, canonical)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to infer environment type canonical", err.Error())
+		return
+	}
+
+	body := &models.NewEnvironmentType{
+		Name:      &name,
+		Canonical: canonical,
+		Color:     &color,
+	}
+
+	et, _, err := r.provider.Middleware.CreateEnvironmentType(org, body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create environment type", err.Error())
+		return
+	}
+
+	environmentTypeCYModelToData(org, et, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *environmentTypeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data environmentTypeResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	et, _, err := r.provider.Middleware.GetEnvironmentType(org, canonical)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to read environment type", err.Error())
+		return
+	}
+
+	environmentTypeCYModelToData(org, et, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *environmentTypeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data environmentTypeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+	name := data.Name.ValueString()
+	color := data.Color.ValueString()
+
+	body := &models.UpdateEnvironmentType{
+		Name:  &name,
+		Color: &color,
+	}
+
+	et, _, err := r.provider.Middleware.UpdateEnvironmentType(org, canonical, body)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update environment type", err.Error())
+		return
+	}
+
+	environmentTypeCYModelToData(org, et, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *environmentTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data environmentTypeResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	canonical := data.Canonical.ValueString()
+
+	_, err := r.provider.Middleware.DeleteEnvironmentType(org, canonical)
+	if err != nil && !isNotFoundError(err) {
+		resp.Diagnostics.AddError("failed to delete environment type", err.Error())
+	}
+}
+
+func (r *environmentTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("canonical"), req, resp)
+}
+
+func environmentTypeCYModelToData(org string, et *models.EnvironmentType, data *environmentTypeResourceModel) {
+	data.Organization = types.StringValue(org)
+	data.Canonical = types.StringPointerValue(et.Canonical)
+	data.Name = types.StringPointerValue(et.Name)
+	data.Color = types.StringPointerValue(et.Color)
+	data.IsDefault = types.BoolPointerValue(et.IsDefault)
+	data.EnvironmentsCount = ptrUint32ToInt64(et.EnvironmentsCount)
+	data.ID = ptrUint32ToInt64(et.ID)
+}

--- a/provider/environment_type_resource_test.go
+++ b/provider/environment_type_resource_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccEnvironmentTypeResource_basic(t *testing.T) {
+	t.Parallel()
+
+	typeName := RandomCanonical("test-env-type")
+	updatedName := typeName + "-updated"
+
+	ctx := context.Background()
+	orgCanonical := testAccGetOrganizationCanonical()
+
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			// Create
+			{
+				Config: testAccEnvironmentTypeConfig_basic(orgCanonical, typeName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_environment_type.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_environment_type.test", "name", typeName),
+					resource.TestCheckResourceAttrSet("cycloid_environment_type.test", "canonical"),
+					resource.TestCheckResourceAttrSet("cycloid_environment_type.test", "id"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "cycloid_environment_type.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs := s.RootModule().Resources["cycloid_environment_type.test"]
+					if rs == nil {
+						return "", fmt.Errorf("cycloid_environment_type.test not in state")
+					}
+					return rs.Primary.Attributes["canonical"], nil
+				},
+				ImportStateVerifyIgnore: []string{"organization"},
+			},
+			// Update
+			{
+				Config: testAccEnvironmentTypeConfig_basic(orgCanonical, updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_environment_type.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_environment_type.test", "name", updatedName),
+				),
+			},
+			// Destroy
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
+func testAccEnvironmentTypeConfig_basic(org, name string) string {
+	return fmt.Sprintf(`
+resource "cycloid_environment_type" "test" {
+  organization = "%s"
+  name         = "%s"
+  color        = "#3498db"
+}
+`, org, name)
+}

--- a/provider/environment_types_datasource.go
+++ b/provider/environment_types_datasource.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_environment_types"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &environmentTypesDataSource{}
+
+type environmentTypesDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewEnvironmentTypesDataSource() datasource.DataSource {
+	return &environmentTypesDataSource{}
+}
+
+func (s *environmentTypesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environment_types"
+}
+
+func (s *environmentTypesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_environment_types.EnvironmentTypesDataSourceSchema(ctx)
+}
+
+func (s *environmentTypesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+var envTypeObjAttrTypes = map[string]attr.Type{
+	"canonical":          types.StringType,
+	"name":               types.StringType,
+	"color":              types.StringType,
+	"is_default":         types.BoolType,
+	"environments_count": types.Int64Type,
+	"id":                 types.Int64Type,
+}
+
+func (s *environmentTypesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_environment_types.EnvironmentTypesModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+
+	ets, _, err := s.provider.Middleware.ListEnvironmentTypes(org)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list environment types", err.Error())
+		return
+	}
+
+	items := make([]attr.Value, len(ets))
+	for i, et := range ets {
+		obj, objDiags := types.ObjectValue(envTypeObjAttrTypes, map[string]attr.Value{
+			"canonical":          types.StringPointerValue(et.Canonical),
+			"name":               types.StringPointerValue(et.Name),
+			"color":              types.StringPointerValue(et.Color),
+			"is_default":         types.BoolPointerValue(et.IsDefault),
+			"environments_count": ptrUint32ToInt64(et.EnvironmentsCount),
+			"id":                 ptrUint32ToInt64(et.ID),
+		})
+		resp.Diagnostics.Append(objDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		items[i] = obj
+	}
+
+	listVal, listDiags := types.ListValue(types.ObjectType{AttrTypes: envTypeObjAttrTypes}, items)
+	resp.Diagnostics.Append(listDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.EnvironmentTypes = listVal
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/provider/environments_datasource.go
+++ b/provider/environments_datasource.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/datasource_environments"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &environmentsDataSource{}
+
+type environmentsDataSource struct {
+	provider *CycloidProvider
+}
+
+func NewEnvironmentsDataSource() datasource.DataSource {
+	return &environmentsDataSource{}
+}
+
+func (s *environmentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_environments"
+}
+
+func (s *environmentsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = datasource_environments.EnvironmentsDataSourceSchema(ctx)
+}
+
+func (s *environmentsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+	s.provider = pv
+}
+
+var environmentListObjAttrTypes = map[string]attr.Type{
+	"canonical":       types.StringType,
+	"name":            types.StringType,
+	"description":     types.StringType,
+	"type":            types.StringType,
+	"owner":           types.StringType,
+	"resources_count": types.Int64Type,
+	"id":              types.Int64Type,
+	"created_at":      types.Int64Type,
+	"updated_at":      types.Int64Type,
+}
+
+func (s *environmentsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data datasource_environments.EnvironmentsModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*s.provider, data.Organization)
+	project := data.Project.ValueString()
+
+	envs, _, err := s.provider.Middleware.ListOrgEnvs(org)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list environments", err.Error())
+		return
+	}
+
+	// When project filter is set, restrict to envs linked to that project.
+	var allowedCanonicals []string
+	if project != "" {
+		projEnvs, _, err := s.provider.Middleware.ListProjectEnvs(org, project)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to list project environments for filter", err.Error())
+			return
+		}
+		for _, pe := range projEnvs {
+			if pe.Canonical != nil {
+				allowedCanonicals = append(allowedCanonicals, *pe.Canonical)
+			}
+		}
+	}
+
+	items := make([]attr.Value, 0, len(envs))
+	for _, env := range envs {
+		if project != "" && !slices.Contains(allowedCanonicals, envCanonical(env)) {
+			continue
+		}
+
+		obj, objDiags := types.ObjectValue(environmentListObjAttrTypes, envToListObj(env))
+		resp.Diagnostics.Append(objDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		items = append(items, obj)
+	}
+
+	listVal, listDiags := types.ListValue(types.ObjectType{AttrTypes: environmentListObjAttrTypes}, items)
+	resp.Diagnostics.Append(listDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Organization = types.StringValue(org)
+	data.Environments = listVal
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func envCanonical(env *models.Environment) string {
+	if env.Canonical == nil {
+		return ""
+	}
+	return *env.Canonical
+}
+
+func envToListObj(env *models.Environment) map[string]attr.Value {
+	envType := types.StringNull()
+	if env.EnvironmentType != nil {
+		envType = types.StringPointerValue(env.EnvironmentType.Canonical)
+	}
+
+	owner := ""
+	if env.Owner != nil && env.Owner.Username != nil {
+		owner = *env.Owner.Username
+	}
+
+	return map[string]attr.Value{
+		"canonical":       types.StringPointerValue(env.Canonical),
+		"name":            types.StringValue(env.Name),
+		"description":     types.StringValue(env.Description),
+		"type":            envType,
+		"owner":           types.StringValue(owner),
+		"resources_count": ptrUint32ToInt64(env.ResourcesCount),
+		"id":              ptrUint32ToInt64(env.ID),
+		"created_at":      ptrUint64ToInt64(env.CreatedAt),
+		"updated_at":      ptrUint64ToInt64(env.UpdatedAt),
+	}
+}

--- a/provider/not_found.go
+++ b/provider/not_found.go
@@ -12,7 +12,10 @@ func isNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-
+	var apiErr *cycloidmiddleware.APIResponseError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
+	}
 	errMessage := strings.ToLower(err.Error())
 	return strings.Contains(errMessage, " not found") ||
 		strings.Contains(errMessage, "notfound") ||

--- a/provider/not_found_test.go
+++ b/provider/not_found_test.go
@@ -36,6 +36,16 @@ func TestIsNotFoundError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "*APIResponseError 404",
+			err:      &cycloidmiddleware.APIResponseError{StatusCode: http.StatusNotFound, Status: "404 Not Found"},
+			expected: true,
+		},
+		{
+			name:     "*APIResponseError 500",
+			err:      &cycloidmiddleware.APIResponseError{StatusCode: http.StatusInternalServerError, Status: "500 Internal Server Error"},
+			expected: false,
+		},
+		{
 			name:     "non not found error",
 			err:      errors.New("A 500 error was returned on \"getConfigRepository\" call"),
 			expected: false,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -134,6 +134,12 @@ func (p *CycloidProvider) DataSources(ctx context.Context) []func() datasource.D
 		NewPluginVersionDataSource,
 		NewPluginManagerDataSource,
 		NewOrganizationMembersDataSource,
+		NewEnvironmentTypeDataSource,
+		NewEnvironmentTypesDataSource,
+		NewCloudAccountDataSource,
+		NewCloudAccountsDataSource,
+		NewEnvironmentDataSource,
+		NewEnvironmentsDataSource,
 	}
 }
 
@@ -157,6 +163,9 @@ func (p *CycloidProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewPluginRegistryPluginResource,
 		NewPluginVersionResource,
 		NewPluginResource,
+		NewEnvironmentTypeResource,
+		NewCloudAccountResource,
+		NewEnvironmentLinkResource,
 	}
 }
 

--- a/provider/test_dependencies.go
+++ b/provider/test_dependencies.go
@@ -117,12 +117,9 @@ func (dm *TestDependencyManager) EnsureTestProject(ctx context.Context, t *testi
 
 // CreateTestEnvironment creates a test environment inside a project using middleware and returns the full environment model.
 func (dm *TestDependencyManager) CreateTestEnvironment(ctx context.Context, t *testing.T, org, project, name string) (*models.Environment, error) {
-	const defaultEnvType = "production" // TODO(meta-gov-env): remove once backend infers type from canonical
-
 	env, _, err := dm.provider.Middleware.CreateOrgEnv(org, &models.NewEnvironment{
 		Canonical: name,
 		Name:      ptr.Ptr(name),
-		Type:      ptr.Ptr(defaultEnvType),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test environment: %w", err)

--- a/provider/test_dependencies.go
+++ b/provider/test_dependencies.go
@@ -117,9 +117,19 @@ func (dm *TestDependencyManager) EnsureTestProject(ctx context.Context, t *testi
 
 // CreateTestEnvironment creates a test environment inside a project using middleware and returns the full environment model.
 func (dm *TestDependencyManager) CreateTestEnvironment(ctx context.Context, t *testing.T, org, project, name string) (*models.Environment, error) {
-	env, _, err := dm.provider.Middleware.CreateEnv(org, project, name, name, "")
+	const defaultEnvType = "production" // TODO(meta-gov-env): remove once backend infers type from canonical
+
+	env, _, err := dm.provider.Middleware.CreateOrgEnv(org, &models.NewEnvironment{
+		Canonical: name,
+		Name:      ptr.Ptr(name),
+		Type:      ptr.Ptr(defaultEnvType),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test environment: %w", err)
+	}
+
+	if _, err := dm.provider.Middleware.LinkEnvToProject(org, project, name); err != nil {
+		return nil, fmt.Errorf("failed to link test environment to project: %w", err)
 	}
 
 	canonical := *env.Canonical
@@ -127,7 +137,10 @@ func (dm *TestDependencyManager) CreateTestEnvironment(ctx context.Context, t *t
 		resourceType: "environment",
 		canonical:    canonical,
 		cleanupFunc: func() error {
-			_, err := dm.provider.Middleware.DeleteEnv(org, project, canonical, middleware.DeleteOptions{})
+			if _, err := dm.provider.Middleware.UnlinkEnvFromProject(org, project, canonical, middleware.DeleteOptions{}); err != nil {
+				return err
+			}
+			_, err := dm.provider.Middleware.DeleteOrgEnv(org, canonical)
 			return err
 		},
 	})
@@ -144,7 +157,7 @@ func (dm *TestDependencyManager) EnsureTestEnvironment(ctx context.Context, t *t
 		t.Skip("skipping acceptance test: CY_API_URL, CY_API_KEY and CY_ORG must be set")
 	}
 
-	envs, _, err := dm.provider.Middleware.ListProjectsEnv(org, project)
+	envs, _, err := dm.provider.Middleware.ListProjectEnvs(org, project)
 	if err != nil {
 		t.Logf("Warning: failed to list environments, will attempt to create: %v", err)
 	}
@@ -152,7 +165,8 @@ func (dm *TestDependencyManager) EnsureTestEnvironment(ctx context.Context, t *t
 	for _, e := range envs {
 		if ptr.Value(e.Canonical) == name {
 			t.Logf("Test environment already exists: %s in project %s", name, project)
-			return e, nil
+			env, _, err := dm.provider.Middleware.GetOrgEnv(org, name)
+			return env, err
 		}
 	}
 

--- a/resource_cloud_account/cloud_account_resource_schema.go
+++ b/resource_cloud_account/cloud_account_resource_schema.go
@@ -1,0 +1,110 @@
+package resource_cloud_account
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func CloudAccountResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Manage organization-scoped Cloud Accounts in Cycloid. A Cloud Account wraps a `cycloid_credential` and binds it to a cloud provider so it can be linked to environments. Built-in providers are `aws`, `google` and `azurerm`; any other canonical is treated as a custom provider for the organization.",
+		MarkdownDescription: "Manage organization-scoped Cloud Accounts in Cycloid. A Cloud Account wraps a [`cycloid_credential`](./credential.md) and binds it to a cloud provider so it can be linked to environments. Built-in providers are `aws`, `google` and `azurerm`; any other canonical is treated as a custom provider for the organization.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical where the cloud account lives. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical where the cloud account lives. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				Description:         "Display name for the cloud account, shown in the UI. Either `name` or `canonical` must be set.",
+				MarkdownDescription: "Display name for the cloud account, shown in the UI. Either `name` or `canonical` must be set.",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 255),
+					stringvalidator.AtLeastOneOf(
+						path.MatchRoot("name"),
+						path.MatchRoot("canonical"),
+					),
+				},
+			},
+			"canonical": schema.StringAttribute{
+				Description:         "Stable identifier for the cloud account. Lower-case alphanumerics with `-_` separators, 3-100 chars. Inferred from `name` when omitted. Changing the canonical forces a replacement.",
+				MarkdownDescription: "Stable identifier for the cloud account. Lower-case alphanumerics with `-_` separators, 3-100 chars. Inferred from `name` when omitted. Changing the canonical forces a replacement.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z0-9]+[a-z0-9\-_]+[a-z0-9]+$`),
+						"must match ^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$",
+					),
+				},
+			},
+			"cloud_provider": schema.StringAttribute{
+				Description:         "Canonical of the cloud provider this account targets. Built-ins: `aws`, `google`, `azurerm` (aliases like `gcp` and `microsoft_azure` are normalized server-side). Any other canonical is treated as a custom org-scoped provider. Cannot be changed after creation; updates trigger replacement.",
+				MarkdownDescription: "Canonical of the cloud provider this account targets. Built-ins: `aws`, `google`, `azurerm` (aliases like `gcp` and `microsoft_azure` are normalized server-side). Any other canonical is treated as a custom org-scoped provider. Cannot be changed after creation; updates trigger replacement.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z0-9]+[a-z0-9\-_]+[a-z0-9]+$`),
+						"must match ^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$",
+					),
+				},
+			},
+			"credential_canonical": schema.StringAttribute{
+				Description:         "Canonical of the `cycloid_credential` to wrap. The credential type must match the cloud provider for built-in providers; any credential type is accepted for custom providers (typically `custom`).",
+				MarkdownDescription: "Canonical of the [`cycloid_credential`](./credential.md) to wrap. The credential type must match the cloud provider for built-in providers; any credential type is accepted for custom providers (typically `custom`).",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+				},
+			},
+			"description": schema.StringAttribute{
+				Description:         "Free-form description of the cloud account.",
+				MarkdownDescription: "Free-form description of the cloud account.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"owner": schema.StringAttribute{
+				Description:         "Username of the organization member that owns this cloud account. The owner has full permissions on the cloud account. Defaults to the API key owner at creation; preserved on update unless explicitly changed.",
+				MarkdownDescription: "Username of the organization member that owns this cloud account. The owner has full permissions on the cloud account. Defaults to the API key owner at creation; preserved on update unless explicitly changed.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"id": schema.Int64Attribute{
+				Description:         "Internal numeric ID assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID assigned by the Cycloid API.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type CloudAccountModel struct {
+	Organization        types.String `tfsdk:"organization"`
+	Name                types.String `tfsdk:"name"`
+	Canonical           types.String `tfsdk:"canonical"`
+	CloudProvider       types.String `tfsdk:"cloud_provider"`
+	CredentialCanonical types.String `tfsdk:"credential_canonical"`
+	Description         types.String `tfsdk:"description"`
+	Owner               types.String `tfsdk:"owner"`
+	ID                  types.Int64  `tfsdk:"id"`
+}

--- a/resource_environment/environment_resource_schema.go
+++ b/resource_environment/environment_resource_schema.go
@@ -6,44 +6,43 @@ import (
 
 	"github.com/cycloidio/terraform-provider-cycloid/internal/icons"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 func EnvironmentResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Description:         "This resource manage Cycloid environments. Environments are part of a project, see `cycloid_project` resource. Docs: https://docs.cycloid.io/reference/core-concepts/",
-		MarkdownDescription: "This resource manage Cycloid environments. Environments are part of a project, see `cycloid_project` resource. [Docs](https://docs.cycloid.io/reference/core-concepts/).",
+		Description:         "This resource manages Cycloid environments. With the org-scoped meta-gov-env API an environment is a first-class organization entity that can be linked to one or more projects. This resource owns one such link via the required `project` attribute; use `cycloid_environment_link` to attach the same environment to additional projects. Docs: https://docs.cycloid.io/reference/core-concepts/",
+		MarkdownDescription: "This resource manages Cycloid environments. With the org-scoped meta-gov-env API an environment is a first-class organization entity that can be linked to one or more projects. This resource owns one such link via the required `project` attribute; use [`cycloid_environment_link`](./environment_link.md) to attach the same environment to additional projects. [Docs](https://docs.cycloid.io/reference/core-concepts/).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
 				Computed:            true,
-				Description:         "The ID of the environment",
-				MarkdownDescription: "The ID of the environment",
+				Description:         "Internal numeric ID of the environment assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID of the environment assigned by the Cycloid API.",
 			},
 			"name": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Display name of the environment, for the UI, either name or canonical must be filled to create a environment",
-				MarkdownDescription: "Display name of the environment, for the UI, either name or canonical must be filled to create a environment",
+				Description:         "Display name of the environment, for the UI. Either `name` or `canonical` must be set.",
+				MarkdownDescription: "Display name of the environment, for the UI. Either `name` or `canonical` must be set.",
 			},
 			"canonical": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "Canonical of the environment, serve as the unique identifier, either name or canonical must be filled to create a environment",
-				MarkdownDescription: "Canonical of the environment, serve as the unique identifier, either name or canonical must be filled to create a environment",
+				Description:         "Stable identifier of the environment. Either `name` or `canonical` must be set.",
+				MarkdownDescription: "Stable identifier of the environment. Either `name` or `canonical` must be set.",
 			},
 			"project": schema.StringAttribute{
 				Required:            true,
-				Description:         "The project canonical where this environent resides",
-				MarkdownDescription: "The project canonical where this environent resides",
+				Description:         "Project canonical that this resource will link the environment to at creation. The environment itself remains an organization-scoped entity; deleting this resource only unlinks it from this project. Use `cycloid_environment_link` for additional projects.",
+				MarkdownDescription: "Project canonical that this resource will link the environment to at creation. The environment itself remains an organization-scoped entity; deleting this resource only unlinks it from this project. Use [`cycloid_environment_link`](./environment_link.md) for additional projects.",
 			},
 			"organization": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The organization where to create the environment, default to the `default_organization` of the provider",
-				MarkdownDescription: "The organization where to create the environment, default to the `default_organization` of the provider",
+				Description:         "The organization where to create the environment. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization where to create the environment. Defaults to the provider's `default_organization`.",
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(3, 100),
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9]+[a-z0-9\-_]+[a-z0-9]+$`), ""),
@@ -52,21 +51,123 @@ func EnvironmentResourceSchema(ctx context.Context) schema.Schema {
 			"color": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The color for the icon displayed in the UI.",
-				MarkdownDescription: "The color for the icon displayed in the UI.",
+				DeprecationMessage:  "color is no longer carried by an environment; it now lives on the linked `cycloid_environment_type`. This attribute is accepted for backward compatibility and ignored on write.",
+				Description:         "Deprecated. Color now lives on the linked `cycloid_environment_type` and is exposed read-only via `type`. Setting this attribute has no effect.",
+				MarkdownDescription: "**Deprecated.** Color now lives on the linked [`cycloid_environment_type`](./environment_type.md) and is exposed read-only via `type`. Setting this attribute has no effect.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(icons.ValidColors...),
 				},
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Free-form description of the environment.",
+				MarkdownDescription: "Free-form description of the environment.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(1000),
+				},
+			},
+			"type": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Canonical of the `cycloid_environment_type` to associate with this environment (e.g. `production`, `staging`). Defaults to `production` until the backend infers the type from the environment canonical.",
+				MarkdownDescription: "Canonical of the [`cycloid_environment_type`](./environment_type.md) to associate with this environment (e.g. `production`, `staging`). Defaults to `production` until the backend infers the type from the environment canonical.",
+			},
+			"owner": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Username of the organization member that owns this environment. The owner has full permissions on the environment. Defaults to the API key owner at creation.",
+				MarkdownDescription: "Username of the organization member that owns this environment. The owner has full permissions on the environment. Defaults to the API key owner at creation.",
+			},
+			"cloud_account_canonicals": schema.ListAttribute{
+				Optional:            true,
+				ElementType:         types.StringType,
+				Description:         "Canonicals of the `cycloid_cloud_account` entries to link to this environment. PATCH semantics: omitting the attribute leaves existing links untouched, an empty list `[]` unlinks all, a non-empty list replaces the set.",
+				MarkdownDescription: "Canonicals of the [`cycloid_cloud_account`](./cloud_account.md) entries to link to this environment. PATCH semantics: omitting the attribute leaves existing links untouched, an empty list `[]` unlinks all, a non-empty list replaces the set.",
+			},
+			"variables": schema.ListNestedAttribute{
+				Optional: true,
+				Description: "Environment variables surfaced under `.environment.variables` during interpolation. PATCH semantics: omit to leave variables untouched, pass `[]` to wipe, pass a non-empty list to replace.",
+				MarkdownDescription: "Environment variables surfaced under `.environment.variables` during interpolation. PATCH semantics: omit to leave variables untouched, pass `[]` to wipe, pass a non-empty list to replace.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"key": schema.StringAttribute{
+							Required:            true,
+							Description:         "Variable identifier referenced as `($ .environment.variables.<key> $)`. Must contain at least one alphanumeric character and no dots.",
+							MarkdownDescription: "Variable identifier referenced as `($ .environment.variables.<key> $)`. Must contain at least one alphanumeric character and no dots.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 255),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^[^.]*[A-Za-z0-9][^.]*$`),
+									"must contain at least one alphanumeric character and no dots",
+								),
+							},
+						},
+						"type": schema.StringAttribute{
+							Required:            true,
+							Description:         "Declared shape of the value. One of: string, boolean, integer, float, array, map.",
+							MarkdownDescription: "Declared shape of the value. One of: `string`, `boolean`, `integer`, `float`, `array`, `map`.",
+							Validators: []validator.String{
+								stringvalidator.OneOf("string", "boolean", "integer", "float", "array", "map"),
+							},
+						},
+						"value": schema.DynamicAttribute{
+							Required:            true,
+							Description:         "The variable value. Its shape must match `type`.",
+							MarkdownDescription: "The variable value. Its shape must match `type`.",
+						},
+						"description": schema.StringAttribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "Free-form description shown in the UI.",
+							MarkdownDescription: "Free-form description shown in the UI.",
+							Validators: []validator.String{
+								stringvalidator.LengthAtMost(1000),
+							},
+						},
+						"sensitive": schema.BoolAttribute{
+							Optional:            true,
+							Computed:            true,
+							Description:         "When true, the UI masks the value. The API still returns the value in plaintext, so prefer `cycloid_credential` for true secrets.",
+							MarkdownDescription: "When true, the UI masks the value. The API still returns the value in plaintext, so prefer [`cycloid_credential`](./credential.md) for true secrets.",
+						},
+					},
+				},
+			},
+			"created_at": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Unix timestamp at which the environment was created.",
+				MarkdownDescription: "Unix timestamp at which the environment was created.",
+			},
+			"updated_at": schema.Int64Attribute{
+				Computed:            true,
+				Description:         "Unix timestamp at which the environment was last updated.",
+				MarkdownDescription: "Unix timestamp at which the environment was last updated.",
 			},
 		},
 	}
 }
 
+type EnvironmentVariableModel struct {
+	Key         types.String  `tfsdk:"key"`
+	Type        types.String  `tfsdk:"type"`
+	Value       types.Dynamic `tfsdk:"value"`
+	Description types.String  `tfsdk:"description"`
+	Sensitive   types.Bool    `tfsdk:"sensitive"`
+}
+
 type EnvironmentModel struct {
-	Project      types.String `tfsdk:"project"`
-	Canonical    types.String `tfsdk:"canonical"`
-	Color        types.String `tfsdk:"color"`
-	ID           types.Int64  `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	Organization types.String `tfsdk:"organization"`
+	Project                types.String `tfsdk:"project"`
+	Canonical              types.String `tfsdk:"canonical"`
+	Color                  types.String `tfsdk:"color"`
+	ID                     types.Int64  `tfsdk:"id"`
+	Name                   types.String `tfsdk:"name"`
+	Organization           types.String `tfsdk:"organization"`
+	Description            types.String `tfsdk:"description"`
+	Type                   types.String `tfsdk:"type"`
+	Owner                  types.String `tfsdk:"owner"`
+	CloudAccountCanonicals types.List   `tfsdk:"cloud_account_canonicals"`
+	Variables              types.List   `tfsdk:"variables"`
+	CreatedAt              types.Int64  `tfsdk:"created_at"`
+	UpdatedAt              types.Int64  `tfsdk:"updated_at"`
 }

--- a/resource_environment/environment_resource_schema.go
+++ b/resource_environment/environment_resource_schema.go
@@ -86,8 +86,8 @@ func EnvironmentResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Canonicals of the [`cycloid_cloud_account`](./cloud_account.md) entries to link to this environment. PATCH semantics: omitting the attribute leaves existing links untouched, an empty list `[]` unlinks all, a non-empty list replaces the set.",
 			},
 			"variables": schema.ListNestedAttribute{
-				Optional: true,
-				Description: "Environment variables surfaced under `.environment.variables` during interpolation. PATCH semantics: omit to leave variables untouched, pass `[]` to wipe, pass a non-empty list to replace.",
+				Optional:            true,
+				Description:         "Environment variables surfaced under `.environment.variables` during interpolation. PATCH semantics: omit to leave variables untouched, pass `[]` to wipe, pass a non-empty list to replace.",
 				MarkdownDescription: "Environment variables surfaced under `.environment.variables` during interpolation. PATCH semantics: omit to leave variables untouched, pass `[]` to wipe, pass a non-empty list to replace.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -111,10 +111,10 @@ func EnvironmentResourceSchema(ctx context.Context) schema.Schema {
 								stringvalidator.OneOf("string", "boolean", "integer", "float", "array", "map"),
 							},
 						},
-						"value": schema.DynamicAttribute{
+						"value": schema.StringAttribute{
 							Required:            true,
-							Description:         "The variable value. Its shape must match `type`.",
-							MarkdownDescription: "The variable value. Its shape must match `type`.",
+							Description:         "The variable value as a string. For non-string types, encode the value as its string representation (e.g. `\"true\"` for boolean, `\"42\"` for integer).",
+							MarkdownDescription: "The variable value as a string. For non-string types, encode the value as its string representation (e.g. `\"true\"` for boolean, `\"42\"` for integer).",
 						},
 						"description": schema.StringAttribute{
 							Optional:            true,
@@ -149,11 +149,11 @@ func EnvironmentResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type EnvironmentVariableModel struct {
-	Key         types.String  `tfsdk:"key"`
-	Type        types.String  `tfsdk:"type"`
-	Value       types.Dynamic `tfsdk:"value"`
-	Description types.String  `tfsdk:"description"`
-	Sensitive   types.Bool    `tfsdk:"sensitive"`
+	Key         types.String `tfsdk:"key"`
+	Type        types.String `tfsdk:"type"`
+	Value       types.String `tfsdk:"value"`
+	Description types.String `tfsdk:"description"`
+	Sensitive   types.Bool   `tfsdk:"sensitive"`
 }
 
 type EnvironmentModel struct {

--- a/resource_environment_link/environment_link_resource_schema.go
+++ b/resource_environment_link/environment_link_resource_schema.go
@@ -1,0 +1,68 @@
+package resource_environment_link
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentLinkResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Attach an existing organization-scoped environment to an additional project. Use this resource for the second, third, ... project link of a shared environment; the first link is owned by the `cycloid_environment` resource via its `project` attribute. Deleting this resource only unlinks the environment from the project, the environment itself is preserved.",
+		MarkdownDescription: "Attach an existing organization-scoped environment to an additional project. Use this resource for the second, third, ... project link of a shared environment; the first link is owned by the [`cycloid_environment`](./environment.md) resource via its `project` attribute. Deleting this resource only unlinks the environment from the project, the environment itself is preserved.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical that owns both the project and the environment. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical that owns both the project and the environment. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+			},
+			"project": schema.StringAttribute{
+				Description:         "Canonical of the project to link the environment to. Changing this attribute forces replacement.",
+				MarkdownDescription: "Canonical of the project to link the environment to. Changing this attribute forces replacement.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+				},
+			},
+			"environment": schema.StringAttribute{
+				Description:         "Canonical of the organization-scoped environment to link. Changing this attribute forces replacement.",
+				MarkdownDescription: "Canonical of the organization-scoped environment to link. Changing this attribute forces replacement.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 100),
+				},
+			},
+			"id": schema.StringAttribute{
+				Description:         "Composite identifier `<organization>/<project>/<environment>` used internally by Terraform.",
+				MarkdownDescription: "Composite identifier `<organization>/<project>/<environment>` used internally by Terraform.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+type EnvironmentLinkModel struct {
+	Organization types.String `tfsdk:"organization"`
+	Project      types.String `tfsdk:"project"`
+	Environment  types.String `tfsdk:"environment"`
+	ID           types.String `tfsdk:"id"`
+}

--- a/resource_environment_type/environment_type_resource_schema.go
+++ b/resource_environment_type/environment_type_resource_schema.go
@@ -30,6 +30,9 @@ func EnvironmentTypeResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Display name of the environment type. Either `name` or `canonical` must be set.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
 				Validators: []validator.String{
 					stringvalidator.AtLeastOneOf(
 						path.MatchRoot("name"),
@@ -57,6 +60,9 @@ func EnvironmentTypeResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
 				MarkdownDescription: "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(64),
 				},

--- a/resource_environment_type/environment_type_resource_schema.go
+++ b/resource_environment_type/environment_type_resource_schema.go
@@ -1,0 +1,91 @@
+package resource_environment_type
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func EnvironmentTypeResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Description:         "Manage organization-scoped environment types in Cycloid. Environment types categorize environments (e.g. production, staging) and carry a color used by the UI. Built-in defaults (production, staging, development) are flagged as `is_default` and cannot be renamed or deleted.",
+		MarkdownDescription: "Manage organization-scoped environment types in Cycloid. Environment types categorize environments (e.g. `production`, `staging`) and carry a color used by the UI. Built-in defaults (`production`, `staging`, `development`) are flagged as `is_default` and cannot be renamed or deleted.",
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "The organization canonical where the environment type lives. Defaults to the provider's `default_organization`.",
+				MarkdownDescription: "The organization canonical where the environment type lives. Defaults to the provider's `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				Description:         "Display name of the environment type. Either `name` or `canonical` must be set.",
+				MarkdownDescription: "Display name of the environment type. Either `name` or `canonical` must be set.",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.AtLeastOneOf(
+						path.MatchRoot("name"),
+						path.MatchRoot("canonical"),
+					),
+				},
+			},
+			"canonical": schema.StringAttribute{
+				Description:         "Stable identifier for the environment type. Lower-case alphanumerics with `-_.` separators, 1-100 chars. Inferred from `name` when omitted.",
+				MarkdownDescription: "Stable identifier for the environment type. Lower-case alphanumerics with `-_.` separators, 1-100 chars. Inferred from `name` when omitted.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 100),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[\da-z]+(?:[\da-z\-._]+[\da-z]|[\da-z])$`),
+						"must match ^[\\da-z]+(?:[\\da-z\\-._]+[\\da-z]|[\\da-z])$",
+					),
+				},
+			},
+			"color": schema.StringAttribute{
+				Description:         "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
+				MarkdownDescription: "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(64),
+				},
+			},
+			"is_default": schema.BoolAttribute{
+				Description:         "True for built-in environment types (`production`, `staging`, `development`). Built-ins cannot be renamed or deleted.",
+				MarkdownDescription: "True for built-in environment types (`production`, `staging`, `development`). Built-ins cannot be renamed or deleted.",
+				Computed:            true,
+			},
+			"environments_count": schema.Int64Attribute{
+				Description:         "Number of environments currently using this type.",
+				MarkdownDescription: "Number of environments currently using this type.",
+				Computed:            true,
+			},
+			"id": schema.Int64Attribute{
+				Description:         "Internal numeric ID assigned by the Cycloid API.",
+				MarkdownDescription: "Internal numeric ID assigned by the Cycloid API.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type EnvironmentTypeModel struct {
+	Organization      types.String `tfsdk:"organization"`
+	Name              types.String `tfsdk:"name"`
+	Canonical         types.String `tfsdk:"canonical"`
+	Color             types.String `tfsdk:"color"`
+	IsDefault         types.Bool   `tfsdk:"is_default"`
+	EnvironmentsCount types.Int64  `tfsdk:"environments_count"`
+	ID                types.Int64  `tfsdk:"id"`
+}

--- a/resource_environment_type/environment_type_resource_schema.go
+++ b/resource_environment_type/environment_type_resource_schema.go
@@ -60,9 +60,6 @@ func EnvironmentTypeResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
 				MarkdownDescription: "Color used to render this environment type in the UI. Free-form string up to 64 chars (hex codes such as `#27ae60` or named colors are accepted).",
 				Required:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(64),
 				},


### PR DESCRIPTION
## Summary

Pre-shot Terraform provider changes for meta-gov-env. **Do not merge until cycloid-cli PR is validated** — uses `replace github.com/cycloidio/cycloid-cli => ../cycloid-cli` locally; swap to a published pseudo-version when CLI lands.

This PR is split in two commits to make review easier:

### 1) `feat(provider): adapt environment resource to org-scoped env API` (80c2d61)

Wire the existing `cycloid_environment` resource onto the new org-scoped CLI middleware. Behavioural deltas:
- Create / Update: `CreateOrgEnv` / `UpdateOrgEnv` + `LinkEnvToProject`
- Read: `ListProjectEnvs` (project membership) + `GetOrgEnv` (full entity)
- Delete: `UnlinkEnvFromProject` (the env stays at org level; this resource only owns the project link)
- `color` schema kept for backward compat; API color now comes from `EnvironmentType` if present
- Test helpers updated to org create + link + unlink/delete cleanup

### 2) `feat(provider): draft schemas for meta-gov-env full parity` (ca8385e)

**Schemas + example HCL only — no CRUD wiring yet.** Lets us review the user-facing surface and lock the API contract before pouring CRUD in.

**Resources drafted** (Go schemas + example `.tf`):
- `cycloid_environment_type` — org-scoped, `name` / `canonical` / `color` + computed `is_default`/`environments_count`
- `cycloid_cloud_account` — org-scoped, **pure** (`credential_canonical` references an existing `cycloid_credential`, no inline credential block to keep gitops lifecycle separation)
- `cycloid_environment_link` — additional project↔env link for shared environments; the first link stays folded into `cycloid_environment`
- `cycloid_environment` extension: `description`, `type`, `owner`, `cloud_account_canonicals` (list, PATCH semantics — null=keep, []=unlink-all, non-empty=replace), `variables` (list of `{key, type, value(dynamic), description, sensitive}`). `color` is marked `Deprecated` and ignored on write since color now lives on `environment_type`.

**Data sources drafted** (single + list each):
- `cycloid_environment_type` / `cycloid_environment_types`
- `cycloid_cloud_account` / `cycloid_cloud_accounts` (filterable on `cloud_provider`)
- `cycloid_environment` / `cycloid_environments` (filterable on `project`)

None of the new resources/data sources are registered in `provider.go` yet — the schemas compile, examples are written, but `terraform apply` against them will say "resource not found". CRUD wiring + acceptance tests + `tfplugindocs` regen come in the follow-up commit on this branch.

### Architectural decisions (locked)

- **Environment granularity = fold + sibling**: `cycloid_environment` keeps `project` required (first link folded for backward compat, no state migration needed); `cycloid_environment_link` covers many-to-many. Fully splitting into separate resources would have required a non-trivial state upgrader (Plugin Framework can't split one resource into two), deferred to a future v1.0.
- **Cloud account = pure credential reference**: no inline credential block. The CLI's `--new-credential` ergonomics doesn't translate to TF lifecycles cleanly; users wire `cycloid_credential` separately.

### Companion CLI PR

cycloidio/cycloid-cli#445

## Test plan

- [x] `go build ./...` (with local CLI replace)
- [x] `go vet ./...` clean
- [x] `go test ./... -short -run 'Test[^A]|TestA[^c]'` (unit tests, acceptance excluded) — green
- [ ] Acceptance test `cycloid_environment` against staging backend
- [ ] Phase 2: implement CRUD for the 4 new/extended resources + 6 data sources, register in `provider.go`, add acceptance tests
- [ ] Remove `replace` directive and pin CLI version after cycloid-cli#445 merge

Made with [Cursor](https://cursor.com)