### PR TITLE
refactor(oidc): consume cycloid-cli middleware methods (synced with cycloid-cli#452)

### DIFF
--- a/examples/resources/cycloid_oidc_group_mapping/resource.tf
+++ b/examples/resources/cycloid_oidc_group_mapping/resource.tf
@@ -1,0 +1,12 @@
+resource "cycloid_oidc_group_mapping" "operators" {
+  organization   = "my-org"
+  group_name     = "FOO_OPERATOR"
+  team_canonical = "operator"
+}
+
+# Map one group to several teams by declaring multiple mappings.
+resource "cycloid_oidc_group_mapping" "operators_lead" {
+  organization   = "my-org"
+  group_name     = "FOO_OPERATOR"
+  team_canonical = "lead"
+}

--- a/examples/resources/cycloid_oidc_integration/resource.tf
+++ b/examples/resources/cycloid_oidc_integration/resource.tf
@@ -1,0 +1,19 @@
+# OIDC integration for a split-network setup where the identity provider is
+# only reachable via an internal discovery URL rather than the public issuer.
+#
+# The client_secret is write-only: Terraform tracks it in state but the API
+# never returns it. Change the value here to rotate the secret; use the
+# has_secret attribute to confirm a secret is stored on the server.
+
+resource "cycloid_oidc_integration" "this" {
+  organization = "my-org"
+  enabled      = true
+
+  issuer        = "https://sso.internal.example.com"
+  discovery_url = "https://sso.internal.example.com/.well-known/openid-configuration"
+  client_id     = "cycloid-prod"
+  client_secret = var.oidc_client_secret
+
+  groups_claim_name   = "groups"
+  session_ttl_seconds = 28800 # 8 hours
+}

--- a/examples/resources/cycloid_oidc_organization_settings/resource.tf
+++ b/examples/resources/cycloid_oidc_organization_settings/resource.tf
@@ -1,0 +1,6 @@
+resource "cycloid_oidc_organization_settings" "this" {
+  organization           = "my-org"
+  default_role_canonical = "member"
+  oidc_managed           = true
+  oidc_no_match_policy   = "eject"
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/cycloidio/terraform-provider-cycloid
 
 go 1.25.0
 
+// DRAFT (synced PR cycloidio/cycloid-cli#452): builds against a local cycloid-cli
+// checkout on branch feat/beta-oidc-group-mappings, which adds the OIDC Middleware
+// methods these resources consume. Un-draft checklist: once that PR merges, drop this
+// replace and `go get github.com/cycloidio/cycloid-cli@<merged-sha> && go mod tidy`.
+replace github.com/cycloidio/cycloid-cli => ../cycloid-cli
+
 require (
 	dario.cat/mergo v1.0.2
 	github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560
+	github.com/cycloidio/cycloid-cli v1.0.98-0.20260619120355-9ad3f304ad0d
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,9 @@ module github.com/cycloidio/terraform-provider-cycloid
 
 go 1.25.0
 
-// DRAFT (synced PR cycloidio/cycloid-cli#452): builds against a local cycloid-cli
-// checkout on branch feat/beta-oidc-group-mappings, which adds the OIDC Middleware
-// methods these resources consume. Un-draft checklist: once that PR merges, drop this
-// replace and `go get github.com/cycloidio/cycloid-cli@<merged-sha> && go mod tidy`.
-replace github.com/cycloidio/cycloid-cli => ../cycloid-cli
-
 require (
 	dario.cat/mergo v1.0.2
-	github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067
+	github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067 h1:3VLXeJdYpSWIDRJRwhEs+93DMnZqp9xDiB3vqVBIIYQ=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260527114514-4123e3e65067/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560 h1:3+Hb2qCbIai8BdCiZY/6M/WcFTJYWHVN3Ofnqjl0a+0=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560 h1:3+Hb2qCbIai8BdCiZY/6M/WcFTJYWHVN3Ofnqjl0a+0=
-github.com/cycloidio/cycloid-cli v1.0.98-0.20260619104205-0a2750e1d560/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260619120355-9ad3f304ad0d h1:uAbaQ1vb58PlRHP/rzvuqojoJJZWb+laRKwgTCooD4M=
+github.com/cycloidio/cycloid-cli v1.0.98-0.20260619120355-9ad3f304ad0d/go.mod h1:FXJb73MmXz4cBzUUx6qXtE/+w5uj9l0nJrC3LPAcYqo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/provider/oidc_group_mapping_resource.go
+++ b/provider/oidc_group_mapping_resource.go
@@ -1,0 +1,197 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_group_mapping"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*oidcGroupMappingResource)(nil)
+
+func NewOIDCGroupMappingResource() resource.Resource {
+	return &oidcGroupMappingResource{}
+}
+
+type oidcGroupMappingResource struct {
+	provider *CycloidProvider
+}
+
+type oidcGroupMappingResourceModel resource_oidc_group_mapping.OidcGroupMappingModel
+
+type oidcGroupMappingTeam struct {
+	ID        uint32 `json:"id"`
+	Canonical string `json:"canonical"`
+}
+
+type oidcGroupMapping struct {
+	ID        uint32               `json:"id"`
+	GroupName string               `json:"group_name"`
+	Team      oidcGroupMappingTeam `json:"team"`
+}
+
+type newOIDCGroupMapping struct {
+	GroupName     string `json:"group_name"`
+	TeamCanonical string `json:"team_canonical"`
+}
+
+func (r *oidcGroupMappingResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_group_mapping"
+}
+
+func (r *oidcGroupMappingResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_oidc_group_mapping.OidcGroupMappingResourceSchema(ctx)
+}
+
+func (r *oidcGroupMappingResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+
+	r.provider = pv
+}
+
+func (r *oidcGroupMappingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data oidcGroupMappingResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	groupName := data.GroupName.ValueString()
+	teamCanonical := data.TeamCanonical.ValueString()
+
+	mapping, err := r.createMapping(org, groupName, teamCanonical)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to create OIDC group mapping for group %q in org %q", groupName, org), err.Error())
+		return
+	}
+
+	oidcGroupMappingToData(org, mapping, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcGroupMappingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data oidcGroupMappingResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	id := uint32(data.ID.ValueInt64())
+
+	mappings, err := r.listMappings(org)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to list OIDC group mappings in org %q", org), err.Error())
+		return
+	}
+
+	var found *oidcGroupMapping
+	for i := range mappings {
+		if mappings[i].ID == id {
+			found = &mappings[i]
+			break
+		}
+	}
+
+	if found == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	oidcGroupMappingToData(org, found, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcGroupMappingResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+	// All fields use RequiresReplace — Update is never called.
+}
+
+func (r *oidcGroupMappingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data oidcGroupMappingResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	id := uint32(data.ID.ValueInt64())
+
+	err := r.deleteMapping(org, id)
+	if err != nil {
+		if isNotFoundError(err) {
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to delete OIDC group mapping %d in org %q", id, org), err.Error())
+	}
+}
+
+func oidcGroupMappingToData(org string, mapping *oidcGroupMapping, data *oidcGroupMappingResourceModel) {
+	data.Organization = types.StringValue(org)
+	data.GroupName = types.StringValue(mapping.GroupName)
+	data.TeamCanonical = types.StringValue(mapping.Team.Canonical)
+	data.ID = types.Int64Value(int64(mapping.ID))
+}
+
+func (r *oidcGroupMappingResource) createMapping(org, groupName, teamCanonical string) (*oidcGroupMapping, error) {
+	body := &newOIDCGroupMapping{
+		GroupName:     groupName,
+		TeamCanonical: teamCanonical,
+	}
+
+	result := &oidcGroupMapping{}
+	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       http.MethodPost,
+		Organization: &org,
+		Route:        []string{"organizations", org, "oidc-group-mappings"},
+		Body:         body,
+	}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *oidcGroupMappingResource) listMappings(org string) ([]oidcGroupMapping, error) {
+	var result []oidcGroupMapping
+	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       http.MethodGet,
+		Organization: &org,
+		Route:        []string{"organizations", org, "oidc-group-mappings"},
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *oidcGroupMappingResource) deleteMapping(org string, id uint32) error {
+	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       http.MethodDelete,
+		Organization: &org,
+		Route:        []string{"organizations", org, "oidc-group-mappings", fmt.Sprintf("%d", id)},
+	}, nil)
+	return err
+}

--- a/provider/oidc_group_mapping_resource.go
+++ b/provider/oidc_group_mapping_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_group_mapping"
@@ -22,22 +21,6 @@ type oidcGroupMappingResource struct {
 }
 
 type oidcGroupMappingResourceModel resource_oidc_group_mapping.OidcGroupMappingModel
-
-type oidcGroupMappingTeam struct {
-	ID        uint32 `json:"id"`
-	Canonical string `json:"canonical"`
-}
-
-type oidcGroupMapping struct {
-	ID        uint32               `json:"id"`
-	GroupName string               `json:"group_name"`
-	Team      oidcGroupMappingTeam `json:"team"`
-}
-
-type newOIDCGroupMapping struct {
-	GroupName     string `json:"group_name"`
-	TeamCanonical string `json:"team_canonical"`
-}
 
 func (r *oidcGroupMappingResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_oidc_group_mapping"
@@ -76,7 +59,7 @@ func (r *oidcGroupMappingResource) Create(ctx context.Context, req resource.Crea
 	groupName := data.GroupName.ValueString()
 	teamCanonical := data.TeamCanonical.ValueString()
 
-	mapping, err := r.createMapping(org, groupName, teamCanonical)
+	mapping, _, err := r.provider.Middleware.CreateOIDCGroupMapping(org, groupName, teamCanonical)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to create OIDC group mapping for group %q in org %q", groupName, org), err.Error())
 		return
@@ -97,7 +80,7 @@ func (r *oidcGroupMappingResource) Read(ctx context.Context, req resource.ReadRe
 	org := getOrganizationCanonical(*r.provider, data.Organization)
 	id := uint32(data.ID.ValueInt64())
 
-	mappings, err := r.listMappings(org)
+	mappings, _, err := r.provider.Middleware.ListOIDCGroupMappings(org)
 	if err != nil {
 		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
@@ -107,10 +90,10 @@ func (r *oidcGroupMappingResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	var found *oidcGroupMapping
-	for i := range mappings {
-		if mappings[i].ID == id {
-			found = &mappings[i]
+	var found *cycloidmiddleware.OIDCGroupMapping
+	for _, m := range mappings {
+		if m.ID == id {
+			found = m
 			break
 		}
 	}
@@ -139,7 +122,7 @@ func (r *oidcGroupMappingResource) Delete(ctx context.Context, req resource.Dele
 	org := getOrganizationCanonical(*r.provider, data.Organization)
 	id := uint32(data.ID.ValueInt64())
 
-	err := r.deleteMapping(org, id)
+	_, err := r.provider.Middleware.DeleteOIDCGroupMapping(org, id)
 	if err != nil {
 		if isNotFoundError(err) {
 			return
@@ -148,50 +131,13 @@ func (r *oidcGroupMappingResource) Delete(ctx context.Context, req resource.Dele
 	}
 }
 
-func oidcGroupMappingToData(org string, mapping *oidcGroupMapping, data *oidcGroupMappingResourceModel) {
+func oidcGroupMappingToData(org string, mapping *cycloidmiddleware.OIDCGroupMapping, data *oidcGroupMappingResourceModel) {
 	data.Organization = types.StringValue(org)
 	data.GroupName = types.StringValue(mapping.GroupName)
-	data.TeamCanonical = types.StringValue(mapping.Team.Canonical)
 	data.ID = types.Int64Value(int64(mapping.ID))
-}
-
-func (r *oidcGroupMappingResource) createMapping(org, groupName, teamCanonical string) (*oidcGroupMapping, error) {
-	body := &newOIDCGroupMapping{
-		GroupName:     groupName,
-		TeamCanonical: teamCanonical,
+	// Team is a pointer in the API response; guard against a mapping whose team
+	// was deleted server-side to avoid a provider panic.
+	if mapping.Team != nil {
+		data.TeamCanonical = types.StringValue(mapping.Team.Canonical)
 	}
-
-	result := &oidcGroupMapping{}
-	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
-		Method:       http.MethodPost,
-		Organization: &org,
-		Route:        []string{"organizations", org, "oidc-group-mappings"},
-		Body:         body,
-	}, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (r *oidcGroupMappingResource) listMappings(org string) ([]oidcGroupMapping, error) {
-	var result []oidcGroupMapping
-	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
-		Method:       http.MethodGet,
-		Organization: &org,
-		Route:        []string{"organizations", org, "oidc-group-mappings"},
-	}, &result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (r *oidcGroupMappingResource) deleteMapping(org string, id uint32) error {
-	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
-		Method:       http.MethodDelete,
-		Organization: &org,
-		Route:        []string{"organizations", org, "oidc-group-mappings", fmt.Sprintf("%d", id)},
-	}, nil)
-	return err
 }

--- a/provider/oidc_group_mapping_resource.go
+++ b/provider/oidc_group_mapping_resource.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_group_mapping"
@@ -11,6 +13,7 @@ import (
 )
 
 var _ resource.Resource = (*oidcGroupMappingResource)(nil)
+var _ resource.ResourceWithImportState = (*oidcGroupMappingResource)(nil)
 
 func NewOIDCGroupMappingResource() resource.Resource {
 	return &oidcGroupMappingResource{}
@@ -131,6 +134,30 @@ func (r *oidcGroupMappingResource) Delete(ctx context.Context, req resource.Dele
 	}
 }
 
+// ImportState supports: terraform import cycloid_oidc_group_mapping.x <org>:<mapping_id>
+func (r *oidcGroupMappingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, ":", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			fmt.Sprintf("expected <organization>:<mapping_id>, got %q", req.ID),
+		)
+		return
+	}
+
+	org := parts[0]
+	id, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid mapping ID in import", err.Error())
+		return
+	}
+
+	var data oidcGroupMappingResourceModel
+	data.Organization = types.StringValue(org)
+	data.ID = types.Int64Value(id)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
 func oidcGroupMappingToData(org string, mapping *cycloidmiddleware.OIDCGroupMapping, data *oidcGroupMappingResourceModel) {
 	data.Organization = types.StringValue(org)
 	data.GroupName = types.StringValue(mapping.GroupName)
@@ -139,5 +166,7 @@ func oidcGroupMappingToData(org string, mapping *cycloidmiddleware.OIDCGroupMapp
 	// was deleted server-side to avoid a provider panic.
 	if mapping.Team != nil {
 		data.TeamCanonical = types.StringValue(mapping.Team.Canonical)
+	} else {
+		data.TeamCanonical = types.StringNull()
 	}
 }

--- a/provider/oidc_integration_resource.go
+++ b/provider/oidc_integration_resource.go
@@ -1,0 +1,273 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_integration"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*oidcIntegrationResource)(nil)
+
+// NewOIDCIntegrationResource is the constructor registered in provider.go.
+func NewOIDCIntegrationResource() resource.Resource {
+	return &oidcIntegrationResource{}
+}
+
+type oidcIntegrationResource struct {
+	provider *CycloidProvider
+}
+
+type oidcIntegrationResourceModel resource_oidc_integration.OidcIntegrationModel
+
+func (r *oidcIntegrationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_integration"
+}
+
+func (r *oidcIntegrationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_oidc_integration.OidcIntegrationResourceSchema(ctx)
+}
+
+func (r *oidcIntegrationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+
+	r.provider = pv
+}
+
+func (r *oidcIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data oidcIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	integration, _, err := r.provider.Middleware.UpdateOIDCIntegration(org, oidcIntegrationConfig(&data))
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to create OIDC integration in org %q", org), err.Error())
+		return
+	}
+
+	oidcIntegrationToData(org, integration, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data oidcIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+
+	integration, _, err := r.provider.Middleware.GetOIDCIntegration(org)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to read OIDC integration in org %q", org), err.Error())
+		return
+	}
+
+	// Map non-secret fields + presence flags. client_secret and ca_cert are
+	// intentionally NOT overwritten: the API never returns them, so we preserve
+	// whatever value is already in state to avoid perpetual drift.
+	oidcIntegrationToData(org, integration, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data oidcIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	integration, _, err := r.provider.Middleware.UpdateOIDCIntegration(org, oidcIntegrationConfig(&data))
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to update OIDC integration in org %q", org), err.Error())
+		return
+	}
+
+	oidcIntegrationToData(org, integration, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Delete has no API counterpart. We disable the integration (PUT with
+// enabled=false) and then remove it from Terraform state. Server-side secrets
+// and config are preserved unchanged.
+func (r *oidcIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data oidcIntegrationResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+
+	_, _, err := r.provider.Middleware.UpdateOIDCIntegration(org, map[string]interface{}{
+		"type":    "AuthenticationOIDC",
+		"enabled": false,
+	})
+	if err != nil {
+		if isNotFoundError(err) {
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to disable OIDC integration in org %q", org), err.Error())
+	}
+}
+
+// oidcIntegrationConfig builds the map[string]interface{} body for
+// UpdateOIDCIntegration. "type" and "enabled" are always sent (required by the
+// backend). All other non-secret fields are included when non-null/non-unknown.
+// Secrets are only included when the plan carries a non-empty string, so that
+// an absent or empty value leaves the stored secret/cert untouched on the
+// server (merge semantics).
+func oidcIntegrationConfig(data *oidcIntegrationResourceModel) map[string]interface{} {
+	cfg := map[string]interface{}{
+		"type":    "AuthenticationOIDC",
+		"enabled": data.Enabled.ValueBool(),
+	}
+
+	if !data.DisplayName.IsNull() && !data.DisplayName.IsUnknown() {
+		cfg["oidc_display_name"] = data.DisplayName.ValueString()
+	}
+	if !data.ClientID.IsNull() && !data.ClientID.IsUnknown() {
+		cfg["oidc_client_id"] = data.ClientID.ValueString()
+	}
+	if !data.Issuer.IsNull() && !data.Issuer.IsUnknown() {
+		cfg["oidc_issuer"] = data.Issuer.ValueString()
+	}
+	if !data.Icon.IsNull() && !data.Icon.IsUnknown() {
+		cfg["oidc_icon"] = data.Icon.ValueString()
+	}
+	if !data.GroupsClaimName.IsNull() && !data.GroupsClaimName.IsUnknown() {
+		cfg["oidc_groups_claim_name"] = data.GroupsClaimName.ValueString()
+	}
+	if !data.DiscoveryURL.IsNull() && !data.DiscoveryURL.IsUnknown() {
+		cfg["oidc_discovery_url"] = data.DiscoveryURL.ValueString()
+	}
+	if !data.SessionTTLSeconds.IsNull() && !data.SessionTTLSeconds.IsUnknown() {
+		cfg["oidc_session_ttl_seconds"] = data.SessionTTLSeconds.ValueInt64()
+	}
+	if !data.ClientSecretJwt.IsNull() && !data.ClientSecretJwt.IsUnknown() {
+		cfg["oidc_client_secret_jwt"] = data.ClientSecretJwt.ValueBool()
+	}
+	if !data.UseCaCert.IsNull() && !data.UseCaCert.IsUnknown() {
+		cfg["oidc_use_ca_cert"] = data.UseCaCert.ValueBool()
+	}
+	if !data.SkipTLSVerify.IsNull() && !data.SkipTLSVerify.IsUnknown() {
+		cfg["oidc_skip_tls_verify"] = data.SkipTLSVerify.ValueBool()
+	}
+	if !data.AllowInsecureDiscovery.IsNull() && !data.AllowInsecureDiscovery.IsUnknown() {
+		cfg["oidc_allow_insecure_discovery"] = data.AllowInsecureDiscovery.ValueBool()
+	}
+
+	// Secrets: only send when the plan carries a non-empty string. An absent or
+	// empty value preserves the stored secret/cert on the server.
+	if v := data.ClientSecret.ValueString(); v != "" {
+		cfg["oidc_client_secret"] = v
+	}
+	if v := data.CaCert.ValueString(); v != "" {
+		cfg["oidc_ca_cert"] = v
+	}
+
+	return cfg
+}
+
+// oidcIntegrationToData maps the API response to the Terraform state model.
+//
+// It sets the organization, all non-secret fields, and the computed presence
+// flags (has_secret, has_ca_certificate).
+//
+// It deliberately does NOT touch data.ClientSecret or data.CaCert. The API
+// never returns those values; overwriting them with an empty string would cause
+// perpetual drift on every subsequent plan. Callers must preserve the prior
+// state values for those two fields.
+func oidcIntegrationToData(org string, i *cycloidmiddleware.OIDCIntegration, data *oidcIntegrationResourceModel) {
+	data.Organization = types.StringValue(org)
+	data.Enabled = types.BoolValue(i.Enabled)
+
+	if i.OidcDisplayName != "" {
+		data.DisplayName = types.StringValue(i.OidcDisplayName)
+	} else {
+		data.DisplayName = types.StringNull()
+	}
+	if i.OidcClientID != "" {
+		data.ClientID = types.StringValue(i.OidcClientID)
+	} else {
+		data.ClientID = types.StringNull()
+	}
+	if i.OidcIssuer != "" {
+		data.Issuer = types.StringValue(i.OidcIssuer)
+	} else {
+		data.Issuer = types.StringNull()
+	}
+	if i.OidcIcon != "" {
+		data.Icon = types.StringValue(i.OidcIcon)
+	} else {
+		data.Icon = types.StringNull()
+	}
+	if i.OidcGroupsClaimName != "" {
+		data.GroupsClaimName = types.StringValue(i.OidcGroupsClaimName)
+	} else {
+		data.GroupsClaimName = types.StringNull()
+	}
+
+	if i.OidcDiscoveryURL != nil {
+		data.DiscoveryURL = types.StringValue(*i.OidcDiscoveryURL)
+	} else {
+		data.DiscoveryURL = types.StringNull()
+	}
+
+	if i.OidcSessionTTLSeconds != nil {
+		data.SessionTTLSeconds = types.Int64Value(*i.OidcSessionTTLSeconds)
+	} else {
+		data.SessionTTLSeconds = types.Int64Null()
+	}
+
+	data.ClientSecretJwt = types.BoolValue(i.OidcClientSecretJwt)
+	data.UseCaCert = types.BoolValue(i.OidcUseCaCert)
+	data.SkipTLSVerify = types.BoolValue(i.OidcSkipTLSVerify)
+
+	if i.OidcAllowInsecureDiscovery != nil {
+		data.AllowInsecureDiscovery = types.BoolValue(*i.OidcAllowInsecureDiscovery)
+	} else {
+		data.AllowInsecureDiscovery = types.BoolNull()
+	}
+
+	// Presence flags — server reports whether a secret/cert is stored.
+	if i.HasSecret != nil {
+		data.HasSecret = types.BoolValue(*i.HasSecret)
+	} else {
+		data.HasSecret = types.BoolValue(false)
+	}
+	if i.HasCaCertificate != nil {
+		data.HasCaCertificate = types.BoolValue(*i.HasCaCertificate)
+	} else {
+		data.HasCaCertificate = types.BoolValue(false)
+	}
+
+	// data.ClientSecret and data.CaCert are intentionally left untouched.
+}

--- a/provider/oidc_integration_resource.go
+++ b/provider/oidc_integration_resource.go
@@ -183,6 +183,9 @@ func oidcIntegrationConfig(data *oidcIntegrationResourceModel) map[string]interf
 	if !data.AllowInsecureDiscovery.IsNull() && !data.AllowInsecureDiscovery.IsUnknown() {
 		cfg["oidc_allow_insecure_discovery"] = data.AllowInsecureDiscovery.ValueBool()
 	}
+	if !data.AdoptManualMembers.IsNull() && !data.AdoptManualMembers.IsUnknown() {
+		cfg["oidc_adopt_manual_members"] = data.AdoptManualMembers.ValueBool()
+	}
 
 	// Secrets: only send when the plan carries a non-empty string. An absent or
 	// empty value preserves the stored secret/cert on the server.
@@ -255,6 +258,11 @@ func oidcIntegrationToData(org string, i *cycloidmiddleware.OIDCIntegration, dat
 		data.AllowInsecureDiscovery = types.BoolValue(*i.OidcAllowInsecureDiscovery)
 	} else {
 		data.AllowInsecureDiscovery = types.BoolNull()
+	}
+	if i.OidcAdoptManualMembers != nil {
+		data.AdoptManualMembers = types.BoolValue(*i.OidcAdoptManualMembers)
+	} else {
+		data.AdoptManualMembers = types.BoolNull()
 	}
 
 	// Presence flags — server reports whether a secret/cert is stored.

--- a/provider/oidc_integration_resource.go
+++ b/provider/oidc_integration_resource.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ resource.Resource = (*oidcIntegrationResource)(nil)
+var _ resource.ResourceWithImportState = (*oidcIntegrationResource)(nil)
 
 // NewOIDCIntegrationResource is the constructor registered in provider.go.
 func NewOIDCIntegrationResource() resource.Resource {
@@ -136,6 +137,13 @@ func (r *oidcIntegrationResource) Delete(ctx context.Context, req resource.Delet
 		}
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to disable OIDC integration in org %q", org), err.Error())
 	}
+}
+
+// ImportState supports: terraform import cycloid_oidc_integration.x <organization>
+func (r *oidcIntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data oidcIntegrationResourceModel
+	data.Organization = types.StringValue(req.ID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 // oidcIntegrationConfig builds the map[string]interface{} body for

--- a/provider/oidc_organization_settings_resource.go
+++ b/provider/oidc_organization_settings_resource.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ resource.Resource = (*oidcOrganizationSettingsResource)(nil)
+var _ resource.ResourceWithImportState = (*oidcOrganizationSettingsResource)(nil)
 
 func NewOIDCOrganizationSettingsResource() resource.Resource {
 	return &oidcOrganizationSettingsResource{}
@@ -110,8 +111,34 @@ func (r *oidcOrganizationSettingsResource) Update(ctx context.Context, req resou
 }
 
 func (r *oidcOrganizationSettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// The Cycloid API exposes no delete for per-organization OIDC settings;
-	// removing the resource only drops it from Terraform state.
+	var data oidcOrganizationSettingsResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+
+	// The API has no delete endpoint. Reset to safe defaults so that
+	// oidc_managed=true + eject is not left active after terraform destroy.
+	_, _, err := r.provider.Middleware.UpdateOIDCOrganizationSettings(org, cycloidmiddleware.UpdateOIDCOrganizationSettings{
+		OIDCManaged:       false,
+		OIDCNoMatchPolicy: "keep_membership",
+	})
+	if err != nil && !isNotFoundError(err) {
+		resp.Diagnostics.AddWarning(
+			"Unable to reset OIDC organization settings",
+			"The resource was removed from Terraform state, but the server-side settings could not be reset to safe defaults. Error: "+err.Error(),
+		)
+	}
+}
+
+// ImportState supports: terraform import cycloid_oidc_organization_settings.x <organization>
+func (r *oidcOrganizationSettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	var data oidcOrganizationSettingsResourceModel
+	data.Organization = types.StringValue(req.ID)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func oidcOrganizationSettingsBody(data *oidcOrganizationSettingsResourceModel) cycloidmiddleware.UpdateOIDCOrganizationSettings {

--- a/provider/oidc_organization_settings_resource.go
+++ b/provider/oidc_organization_settings_resource.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_organization_settings"
@@ -22,12 +21,6 @@ type oidcOrganizationSettingsResource struct {
 }
 
 type oidcOrganizationSettingsResourceModel resource_oidc_organization_settings.OidcOrganizationSettingsModel
-
-type oidcOrganizationSettings struct {
-	DefaultRoleCanonical string `json:"default_role_canonical,omitempty"`
-	OidcManaged          bool   `json:"oidc_managed"`
-	OidcNoMatchPolicy    string `json:"oidc_no_match_policy"`
-}
 
 func (r *oidcOrganizationSettingsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_oidc_organization_settings"
@@ -63,7 +56,7 @@ func (r *oidcOrganizationSettingsResource) Create(ctx context.Context, req resou
 	}
 
 	org := getOrganizationCanonical(*r.provider, data.Organization)
-	settings, err := r.updateSettings(org, oidcOrganizationSettingsBody(&data))
+	settings, _, err := r.provider.Middleware.UpdateOIDCOrganizationSettings(org, oidcOrganizationSettingsBody(&data))
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to create OIDC settings in org %q", org), err.Error())
 		return
@@ -83,7 +76,7 @@ func (r *oidcOrganizationSettingsResource) Read(ctx context.Context, req resourc
 
 	org := getOrganizationCanonical(*r.provider, data.Organization)
 
-	settings, err := r.getSettings(org)
+	settings, _, err := r.provider.Middleware.GetOIDCOrganizationSettings(org)
 	if err != nil {
 		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
@@ -106,7 +99,7 @@ func (r *oidcOrganizationSettingsResource) Update(ctx context.Context, req resou
 	}
 
 	org := getOrganizationCanonical(*r.provider, data.Organization)
-	settings, err := r.updateSettings(org, oidcOrganizationSettingsBody(&data))
+	settings, _, err := r.provider.Middleware.UpdateOIDCOrganizationSettings(org, oidcOrganizationSettingsBody(&data))
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to update OIDC settings in org %q", org), err.Error())
 		return
@@ -121,48 +114,21 @@ func (r *oidcOrganizationSettingsResource) Delete(ctx context.Context, req resou
 	// removing the resource only drops it from Terraform state.
 }
 
-func oidcOrganizationSettingsBody(data *oidcOrganizationSettingsResourceModel) *oidcOrganizationSettings {
-	return &oidcOrganizationSettings{
+func oidcOrganizationSettingsBody(data *oidcOrganizationSettingsResourceModel) cycloidmiddleware.UpdateOIDCOrganizationSettings {
+	return cycloidmiddleware.UpdateOIDCOrganizationSettings{
 		DefaultRoleCanonical: data.DefaultRoleCanonical.ValueString(),
-		OidcManaged:          data.OidcManaged.ValueBool(),
-		OidcNoMatchPolicy:    data.OidcNoMatchPolicy.ValueString(),
+		OIDCManaged:          data.OidcManaged.ValueBool(),
+		OIDCNoMatchPolicy:    data.OidcNoMatchPolicy.ValueString(),
 	}
 }
 
-func oidcOrganizationSettingsToData(org string, settings *oidcOrganizationSettings, data *oidcOrganizationSettingsResourceModel) {
+func oidcOrganizationSettingsToData(org string, settings *cycloidmiddleware.OIDCOrganizationSettings, data *oidcOrganizationSettingsResourceModel) {
 	data.Organization = types.StringValue(org)
 	if settings.DefaultRoleCanonical == "" {
 		data.DefaultRoleCanonical = types.StringNull()
 	} else {
 		data.DefaultRoleCanonical = types.StringValue(settings.DefaultRoleCanonical)
 	}
-	data.OidcManaged = types.BoolValue(settings.OidcManaged)
-	data.OidcNoMatchPolicy = types.StringValue(settings.OidcNoMatchPolicy)
-}
-
-func (r *oidcOrganizationSettingsResource) getSettings(org string) (*oidcOrganizationSettings, error) {
-	result := &oidcOrganizationSettings{}
-	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
-		Method:       http.MethodGet,
-		Organization: &org,
-		Route:        []string{"organizations", org, "oidc-organization-settings"},
-	}, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func (r *oidcOrganizationSettingsResource) updateSettings(org string, body *oidcOrganizationSettings) (*oidcOrganizationSettings, error) {
-	result := &oidcOrganizationSettings{}
-	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
-		Method:       http.MethodPut,
-		Organization: &org,
-		Route:        []string{"organizations", org, "oidc-organization-settings"},
-		Body:         body,
-	}, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	data.OidcManaged = types.BoolValue(settings.OIDCManaged)
+	data.OidcNoMatchPolicy = types.StringValue(settings.OIDCNoMatchPolicy)
 }

--- a/provider/oidc_organization_settings_resource.go
+++ b/provider/oidc_organization_settings_resource.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	cycloidmiddleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_oidc_organization_settings"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*oidcOrganizationSettingsResource)(nil)
+
+func NewOIDCOrganizationSettingsResource() resource.Resource {
+	return &oidcOrganizationSettingsResource{}
+}
+
+type oidcOrganizationSettingsResource struct {
+	provider *CycloidProvider
+}
+
+type oidcOrganizationSettingsResourceModel resource_oidc_organization_settings.OidcOrganizationSettingsModel
+
+type oidcOrganizationSettings struct {
+	DefaultRoleCanonical string `json:"default_role_canonical,omitempty"`
+	OidcManaged          bool   `json:"oidc_managed"`
+	OidcNoMatchPolicy    string `json:"oidc_no_match_policy"`
+}
+
+func (r *oidcOrganizationSettingsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_organization_settings"
+}
+
+func (r *oidcOrganizationSettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = resource_oidc_organization_settings.OidcOrganizationSettingsResourceSchema(ctx)
+}
+
+func (r *oidcOrganizationSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	pv, ok := req.ProviderData.(*CycloidProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Provider data at Configure()",
+			fmt.Sprintf("Expected *CycloidProvider, got: %T. Please report this issue.", req.ProviderData),
+		)
+		return
+	}
+
+	r.provider = pv
+}
+
+func (r *oidcOrganizationSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data oidcOrganizationSettingsResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	settings, err := r.updateSettings(org, oidcOrganizationSettingsBody(&data))
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to create OIDC settings in org %q", org), err.Error())
+		return
+	}
+
+	oidcOrganizationSettingsToData(org, settings, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcOrganizationSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data oidcOrganizationSettingsResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+
+	settings, err := r.getSettings(org)
+	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to read OIDC settings in org %q", org), err.Error())
+		return
+	}
+
+	oidcOrganizationSettingsToData(org, settings, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcOrganizationSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data oidcOrganizationSettingsResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	settings, err := r.updateSettings(org, oidcOrganizationSettingsBody(&data))
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to update OIDC settings in org %q", org), err.Error())
+		return
+	}
+
+	oidcOrganizationSettingsToData(org, settings, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *oidcOrganizationSettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// The Cycloid API exposes no delete for per-organization OIDC settings;
+	// removing the resource only drops it from Terraform state.
+}
+
+func oidcOrganizationSettingsBody(data *oidcOrganizationSettingsResourceModel) *oidcOrganizationSettings {
+	return &oidcOrganizationSettings{
+		DefaultRoleCanonical: data.DefaultRoleCanonical.ValueString(),
+		OidcManaged:          data.OidcManaged.ValueBool(),
+		OidcNoMatchPolicy:    data.OidcNoMatchPolicy.ValueString(),
+	}
+}
+
+func oidcOrganizationSettingsToData(org string, settings *oidcOrganizationSettings, data *oidcOrganizationSettingsResourceModel) {
+	data.Organization = types.StringValue(org)
+	if settings.DefaultRoleCanonical == "" {
+		data.DefaultRoleCanonical = types.StringNull()
+	} else {
+		data.DefaultRoleCanonical = types.StringValue(settings.DefaultRoleCanonical)
+	}
+	data.OidcManaged = types.BoolValue(settings.OidcManaged)
+	data.OidcNoMatchPolicy = types.StringValue(settings.OidcNoMatchPolicy)
+}
+
+func (r *oidcOrganizationSettingsResource) getSettings(org string) (*oidcOrganizationSettings, error) {
+	result := &oidcOrganizationSettings{}
+	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       http.MethodGet,
+		Organization: &org,
+		Route:        []string{"organizations", org, "oidc-organization-settings"},
+	}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *oidcOrganizationSettingsResource) updateSettings(org string, body *oidcOrganizationSettings) (*oidcOrganizationSettings, error) {
+	result := &oidcOrganizationSettings{}
+	_, err := r.provider.Middleware.GenericRequest(cycloidmiddleware.Request{
+		Method:       http.MethodPut,
+		Organization: &org,
+		Route:        []string{"organizations", org, "oidc-organization-settings"},
+		Body:         body,
+	}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -166,6 +166,8 @@ func (p *CycloidProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewEnvironmentTypeResource,
 		NewCloudAccountResource,
 		NewEnvironmentLinkResource,
+		NewOIDCGroupMappingResource,
+		NewOIDCOrganizationSettingsResource,
 	}
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -168,6 +168,7 @@ func (p *CycloidProvider) Resources(ctx context.Context) []func() resource.Resou
 		NewEnvironmentLinkResource,
 		NewOIDCGroupMappingResource,
 		NewOIDCOrganizationSettingsResource,
+		NewOIDCIntegrationResource,
 	}
 }
 

--- a/resource_oidc_group_mapping/oidc_group_mapping_schema.go
+++ b/resource_oidc_group_mapping/oidc_group_mapping_schema.go
@@ -1,0 +1,77 @@
+package resource_oidc_group_mapping
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func OidcGroupMappingResourceSchema(ctx context.Context) schema.Schema {
+	desc := strings.Join([]string{
+		"Maps an OIDC group claim to a team within an organization.",
+		"The org-level role granted to OIDC-managed users is driven by the per-organization OIDC settings (`cycloid_oidc_organization_settings.default_role_canonical`), not by the mapping.",
+		"Assign a group to several teams by declaring multiple mappings.",
+	}, "\n")
+
+	return schema.Schema{
+		Description:         desc,
+		MarkdownDescription: desc,
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "Organization canonical where to manage the mapping. Defaults to provider `default_organization`.",
+				MarkdownDescription: "Organization canonical where to manage the mapping. Defaults to provider `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$"), ""),
+				},
+			},
+			"group_name": schema.StringAttribute{
+				Description:         "The OIDC group claim value to match.",
+				MarkdownDescription: "The OIDC group claim value to match.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 255),
+				},
+			},
+			"team_canonical": schema.StringAttribute{
+				Description:         "The canonical of the team the user is added to when this mapping matches.",
+				MarkdownDescription: "The canonical of the team the user is added to when this mapping matches.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$"), ""),
+				},
+			},
+			"id": schema.Int64Attribute{
+				Description:         "OIDC group mapping identifier.",
+				MarkdownDescription: "OIDC group mapping identifier.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+type OidcGroupMappingModel struct {
+	Organization  types.String `tfsdk:"organization"`
+	GroupName     types.String `tfsdk:"group_name"`
+	TeamCanonical types.String `tfsdk:"team_canonical"`
+	ID            types.Int64  `tfsdk:"id"`
+}

--- a/resource_oidc_integration/oidc_integration_schema.go
+++ b/resource_oidc_integration/oidc_integration_schema.go
@@ -104,6 +104,11 @@ func OidcIntegrationResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "When true, the OIDC discovery document may be fetched over HTTP (insecure). Use only in non-production environments.",
 				Optional:            true,
 			},
+			"adopt_manual_members": schema.BoolAttribute{
+				Description:         "When true, existing manually-invited members who log in via this OIDC integration are adopted — their membership source is flipped to 'oidc' so group mapping manages them going forward.",
+				MarkdownDescription: "When true, existing manually-invited members who log in via this OIDC integration are adopted — their membership source is flipped to `oidc` so group mapping manages them going forward.",
+				Optional:            true,
+			},
 
 			// --- write-only secrets ---
 			"client_secret": schema.StringAttribute{
@@ -149,6 +154,7 @@ type OidcIntegrationModel struct {
 	UseCaCert              types.Bool   `tfsdk:"use_ca_cert"`
 	SkipTLSVerify          types.Bool   `tfsdk:"skip_tls_verify"`
 	AllowInsecureDiscovery types.Bool   `tfsdk:"allow_insecure_discovery"`
+	AdoptManualMembers     types.Bool   `tfsdk:"adopt_manual_members"`
 	ClientSecret           types.String `tfsdk:"client_secret"`
 	CaCert                 types.String `tfsdk:"ca_cert"`
 	HasSecret              types.Bool   `tfsdk:"has_secret"`

--- a/resource_oidc_integration/oidc_integration_schema.go
+++ b/resource_oidc_integration/oidc_integration_schema.go
@@ -88,26 +88,31 @@ func OidcIntegrationResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "When true, the client authenticates to the token endpoint using a JWT signed with the client secret (private_key_jwt).",
 				MarkdownDescription: "When true, the client authenticates to the token endpoint using a JWT signed with the client secret (private_key_jwt).",
 				Optional:            true,
+				Computed:            true,
 			},
 			"use_ca_cert": schema.BoolAttribute{
 				Description:         "When true, the custom CA certificate (see `ca_cert`) is used to verify the identity provider's TLS certificate.",
 				MarkdownDescription: "When true, the custom CA certificate (see `ca_cert`) is used to verify the identity provider's TLS certificate.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"skip_tls_verify": schema.BoolAttribute{
 				Description:         "When true, TLS certificate verification is skipped for the identity provider endpoints. Use only in non-production environments.",
 				MarkdownDescription: "When true, TLS certificate verification is skipped for the identity provider endpoints. Use only in non-production environments.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"allow_insecure_discovery": schema.BoolAttribute{
 				Description:         "When true, the OIDC discovery document may be fetched over HTTP (insecure). Use only in non-production environments.",
 				MarkdownDescription: "When true, the OIDC discovery document may be fetched over HTTP (insecure). Use only in non-production environments.",
 				Optional:            true,
+				Computed:            true,
 			},
 			"adopt_manual_members": schema.BoolAttribute{
 				Description:         "When true, existing manually-invited members who log in via this OIDC integration are adopted — their membership source is flipped to 'oidc' so group mapping manages them going forward.",
 				MarkdownDescription: "When true, existing manually-invited members who log in via this OIDC integration are adopted — their membership source is flipped to `oidc` so group mapping manages them going forward.",
 				Optional:            true,
+				Computed:            true,
 			},
 
 			// --- write-only secrets ---

--- a/resource_oidc_integration/oidc_integration_schema.go
+++ b/resource_oidc_integration/oidc_integration_schema.go
@@ -1,0 +1,156 @@
+package resource_oidc_integration
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func OidcIntegrationResourceSchema(ctx context.Context) schema.Schema {
+	desc := strings.Join([]string{
+		"Manages an organization's AuthenticationOIDC SSO integration.",
+		"Singleton resource: one OIDC integration config exists per organization.",
+		"The integration is created/updated via a PUT (merge semantics); absent keys keep their stored values.",
+		"There is no delete API endpoint — removing this resource disables the integration (`enabled = false`) and drops it from Terraform state.",
+	}, "\n")
+
+	return schema.Schema{
+		Description:         desc,
+		MarkdownDescription: desc,
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "Organization canonical where to manage the OIDC integration. Defaults to provider `default_organization`.",
+				MarkdownDescription: "Organization canonical where to manage the OIDC integration. Defaults to provider `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9]+[a-z0-9\-_]+[a-z0-9]+$`), ""),
+				},
+			},
+
+			// --- required ---
+			"enabled": schema.BoolAttribute{
+				Description:         "Whether the OIDC SSO integration is active for the organization.",
+				MarkdownDescription: "Whether the OIDC SSO integration is active for the organization.",
+				Required:            true,
+			},
+
+			// --- optional non-secret ---
+			"display_name": schema.StringAttribute{
+				Description:         "Human-readable label shown on the login page for this OIDC provider.",
+				MarkdownDescription: "Human-readable label shown on the login page for this OIDC provider.",
+				Optional:            true,
+			},
+			"client_id": schema.StringAttribute{
+				Description:         "OIDC client ID registered with the identity provider.",
+				MarkdownDescription: "OIDC client ID registered with the identity provider.",
+				Optional:            true,
+			},
+			"issuer": schema.StringAttribute{
+				Description:         "OIDC issuer URL of the identity provider.",
+				MarkdownDescription: "OIDC issuer URL of the identity provider.",
+				Optional:            true,
+			},
+			"icon": schema.StringAttribute{
+				Description:         "URL or name of the icon displayed on the login button.",
+				MarkdownDescription: "URL or name of the icon displayed on the login button.",
+				Optional:            true,
+			},
+			"groups_claim_name": schema.StringAttribute{
+				Description:         "Name of the claim in the OIDC token that carries the user's group memberships.",
+				MarkdownDescription: "Name of the claim in the OIDC token that carries the user's group memberships.",
+				Optional:            true,
+			},
+			"discovery_url": schema.StringAttribute{
+				Description:         "Override URL for the OIDC discovery document (`.well-known/openid-configuration`). When set, `issuer` may be omitted.",
+				MarkdownDescription: "Override URL for the OIDC discovery document (`.well-known/openid-configuration`). When set, `issuer` may be omitted.",
+				Optional:            true,
+			},
+			"session_ttl_seconds": schema.Int64Attribute{
+				Description:         "Session duration in seconds for OIDC-authenticated users. Leave unset to use the provider default.",
+				MarkdownDescription: "Session duration in seconds for OIDC-authenticated users. Leave unset to use the provider default.",
+				Optional:            true,
+			},
+
+			// --- optional bool flags ---
+			"client_secret_jwt": schema.BoolAttribute{
+				Description:         "When true, the client authenticates to the token endpoint using a JWT signed with the client secret (private_key_jwt).",
+				MarkdownDescription: "When true, the client authenticates to the token endpoint using a JWT signed with the client secret (private_key_jwt).",
+				Optional:            true,
+			},
+			"use_ca_cert": schema.BoolAttribute{
+				Description:         "When true, the custom CA certificate (see `ca_cert`) is used to verify the identity provider's TLS certificate.",
+				MarkdownDescription: "When true, the custom CA certificate (see `ca_cert`) is used to verify the identity provider's TLS certificate.",
+				Optional:            true,
+			},
+			"skip_tls_verify": schema.BoolAttribute{
+				Description:         "When true, TLS certificate verification is skipped for the identity provider endpoints. Use only in non-production environments.",
+				MarkdownDescription: "When true, TLS certificate verification is skipped for the identity provider endpoints. Use only in non-production environments.",
+				Optional:            true,
+			},
+			"allow_insecure_discovery": schema.BoolAttribute{
+				Description:         "When true, the OIDC discovery document may be fetched over HTTP (insecure). Use only in non-production environments.",
+				MarkdownDescription: "When true, the OIDC discovery document may be fetched over HTTP (insecure). Use only in non-production environments.",
+				Optional:            true,
+			},
+
+			// --- write-only secrets ---
+			"client_secret": schema.StringAttribute{
+				Description:         "OIDC client secret. Write-only: the API never returns this value. Change the value here to rotate the secret. The `has_secret` attribute reflects whether a secret is currently stored on the server.",
+				MarkdownDescription: "OIDC client secret. Write-only: the API never returns this value. Change the value here to rotate the secret. The `has_secret` attribute reflects whether a secret is currently stored on the server.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"ca_cert": schema.StringAttribute{
+				Description:         "PEM-encoded CA certificate used to verify the identity provider's TLS certificate. Write-only: the API never returns this value. Change the value here to rotate the certificate. The `has_ca_certificate` attribute reflects whether a certificate is currently stored on the server.",
+				MarkdownDescription: "PEM-encoded CA certificate used to verify the identity provider's TLS certificate. Write-only: the API never returns this value. Change the value here to rotate the certificate. The `has_ca_certificate` attribute reflects whether a certificate is currently stored on the server.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+
+			// --- computed presence flags ---
+			"has_secret": schema.BoolAttribute{
+				Description:         "True when the server has a stored client secret. Reflects server state; not settable.",
+				MarkdownDescription: "True when the server has a stored client secret. Reflects server state; not settable.",
+				Computed:            true,
+			},
+			"has_ca_certificate": schema.BoolAttribute{
+				Description:         "True when the server has a stored CA certificate. Reflects server state; not settable.",
+				MarkdownDescription: "True when the server has a stored CA certificate. Reflects server state; not settable.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// OidcIntegrationModel is the Terraform state model for the oidc_integration resource.
+type OidcIntegrationModel struct {
+	Organization           types.String `tfsdk:"organization"`
+	Enabled                types.Bool   `tfsdk:"enabled"`
+	DisplayName            types.String `tfsdk:"display_name"`
+	ClientID               types.String `tfsdk:"client_id"`
+	Issuer                 types.String `tfsdk:"issuer"`
+	Icon                   types.String `tfsdk:"icon"`
+	GroupsClaimName        types.String `tfsdk:"groups_claim_name"`
+	DiscoveryURL           types.String `tfsdk:"discovery_url"`
+	SessionTTLSeconds      types.Int64  `tfsdk:"session_ttl_seconds"`
+	ClientSecretJwt        types.Bool   `tfsdk:"client_secret_jwt"`
+	UseCaCert              types.Bool   `tfsdk:"use_ca_cert"`
+	SkipTLSVerify          types.Bool   `tfsdk:"skip_tls_verify"`
+	AllowInsecureDiscovery types.Bool   `tfsdk:"allow_insecure_discovery"`
+	ClientSecret           types.String `tfsdk:"client_secret"`
+	CaCert                 types.String `tfsdk:"ca_cert"`
+	HasSecret              types.Bool   `tfsdk:"has_secret"`
+	HasCaCertificate       types.Bool   `tfsdk:"has_ca_certificate"`
+}

--- a/resource_oidc_organization_settings/oidc_organization_settings_schema.go
+++ b/resource_oidc_organization_settings/oidc_organization_settings_schema.go
@@ -1,0 +1,72 @@
+package resource_oidc_organization_settings
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func OidcOrganizationSettingsResourceSchema(ctx context.Context) schema.Schema {
+	desc := strings.Join([]string{
+		"Manage the per-organization OIDC reconciliation settings.",
+		"Singleton resource: a single settings row exists per organization.",
+		"`oidc_no_match_policy = \"eject\"` requires `oidc_managed = true`; the API rejects the combination otherwise.",
+	}, "\n")
+
+	return schema.Schema{
+		Description:         desc,
+		MarkdownDescription: desc,
+		Attributes: map[string]schema.Attribute{
+			"organization": schema.StringAttribute{
+				Description:         "Organization canonical where to manage the OIDC settings. Defaults to provider `default_organization`.",
+				MarkdownDescription: "Organization canonical where to manage the OIDC settings. Defaults to provider `default_organization`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$"), ""),
+				},
+			},
+			"default_role_canonical": schema.StringAttribute{
+				Description:         "Canonical of the org-level role granted to OIDC-managed users on provisioning. Leave unset to configure no default role.",
+				MarkdownDescription: "Canonical of the org-level role granted to OIDC-managed users on provisioning. Leave unset to configure no default role.",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 100),
+					stringvalidator.RegexMatches(regexp.MustCompile("^[a-z0-9]+[a-z0-9\\-_]+[a-z0-9]+$"), ""),
+				},
+			},
+			"oidc_managed": schema.BoolAttribute{
+				Description:         "When true, local member/team/invite edits are disabled for the organization (strict mode).",
+				MarkdownDescription: "When true, local member/team/invite edits are disabled for the organization (strict mode).",
+				Required:            true,
+			},
+			"oidc_no_match_policy": schema.StringAttribute{
+				Description:         "Policy applied when no group mapping matches on login. `eject` requires `oidc_managed = true`.",
+				MarkdownDescription: "Policy applied when no group mapping matches on login. `eject` requires `oidc_managed = true`.",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("keep_membership", "eject"),
+				},
+			},
+		},
+	}
+}
+
+type OidcOrganizationSettingsModel struct {
+	Organization         types.String `tfsdk:"organization"`
+	DefaultRoleCanonical types.String `tfsdk:"default_role_canonical"`
+	OidcManaged          types.Bool   `tfsdk:"oidc_managed"`
+	OidcNoMatchPolicy    types.String `tfsdk:"oidc_no_match_policy"`
+}


### PR DESCRIPTION
## What

Reworks the two OIDC resources (`cycloid_oidc_group_mapping`, `cycloid_oidc_organization_settings`) to **consume named `cycloid-cli` middleware methods** instead of issuing raw `GenericRequest` calls with hand-rolled wire structs.

This is the Terraform half of a **synced pair** with **cycloidio/cycloid-cli#452**, which adds the `Middleware` methods consumed here. Together they make the PROD-303 OIDC group-mapping feature scriptable (CLI) and declarative (TF) for end-to-end testing / automation.

## Changes

- `provider/oidc_group_mapping_resource.go` / `oidc_organization_settings_resource.go`: CRUD now calls `CreateOIDCGroupMapping` / `ListOIDCGroupMappings` / `DeleteOIDCGroupMapping` / `GetOIDCOrganizationSettings` / `UpdateOIDCOrganizationSettings` on the `Middleware` interface. The duplicated local wire structs are gone (net −110 lines).
- Nil-guard on the mapping response `Team` pointer (prevents a provider panic if a mapped team was deleted server-side).
- `go.mod`: temporary `replace => ../cycloid-cli` so the provider builds against the branch that adds these methods. Un-draft checklist is in the go.mod comment.

## Why "consume the middleware"

`provider.go` already routes every API call through the cycloid-cli `Middleware` interface; the OIDC resources were the one place still calling `GenericRequest` directly with untyped structs. Promoting those into named middleware methods keeps the wire contract in one place (cycloid-cli) and gives both the CLI and the provider a single typed surface.

## Verification (offline, on this branch)

- `go build ./...` — ✓
- `go vet ./provider/...` — ✓
- `gofmt` — clean
- Acceptance tests not run here (need a live backend + `TF_ACC=1`).

## Status — DRAFT, blocked on the sync

1. Depends on **cycloidio/cycloid-cli#452** (the middleware methods).
1. Un-draft: drop the `replace` in `go.mod`, `go get github.com/cycloidio/cycloid-cli@<merged-sha> && go mod tidy`, then build + acceptance.

The intermediate commit on this branch (the original `GenericRequest` version) is superseded by the middleware-consuming version; the net diff vs `master` is the final state.

______________________________________________________________________

## Update — `cycloid_oidc_integration` resource (SSO config)

Added the **`cycloid_oidc_integration`** resource managing the org's AuthenticationOIDC SSO integration via the same cli middleware (`GetOIDCIntegration` / `UpdateOIDCIntegration`). Full config schema: issuer, client_id, client_secret, `discovery_url`, `session_ttl_seconds`, groups_claim_name, ca_cert, and the TLS/discovery toggles.

- `client_secret` / `ca_cert` are **Sensitive + write-only**: Read never overwrites them from the API (which never returns them) → no perpetual drift; `has_secret` / `has_ca_certificate` computed flags reflect server presence. Rotate by changing the config value.
- Create/Update send the full config (secret only when set); **Delete disables** the integration (`enabled=false`) since the API has no delete, then drops state.
- This lands **`oidc_session_ttl_seconds`** declaratively — closes the carry-forward TTL item.

Known follow-up (LOW, deferred): a plan-time warning when `skip_tls_verify` / `allow_insecure_discovery` = `true` (defaults are safe; the schema descriptions already warn).

Verified offline: build + vet + gofmt clean.
