### PR TITLE
feat(organization_member): expose member_canonical as computed output

### DIFF
--- a/docs/resources/organization_member.md
+++ b/docs/resources/organization_member.md
@@ -66,4 +66,8 @@ terraform {
 - `member_id` (Number) A member id
 - `organization_canonical` (String) A canonical of an organization.
 
+### Read-Only
+
+- `member_canonical` (String) The canonical (username) of the member.
+
 

--- a/provider/organization_member_resource.go
+++ b/provider/organization_member_resource.go
@@ -105,6 +105,7 @@ func orgMemberCYModelToData(org string, m *models.MemberOrg, data *organizationM
 
 	data.OrganizationCanonical = types.StringValue(org)
 	data.MemberId = types.Int64Value(int64(*m.ID))
+	data.MemberCanonical = types.StringValue(m.Username)
 	data.Email = types.StringValue(string(email))
 	data.RoleCanonical = types.StringValue(*m.Role.Canonical)
 

--- a/provider/organization_member_resource_test.go
+++ b/provider/organization_member_resource_test.go
@@ -5,8 +5,59 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// Unit tests — no TF_ACC required
+
+func TestOrgMemberCYModelToData_AcceptedMember(t *testing.T) {
+	id := uint32(42)
+	role := "organization-admin"
+	email := strfmt.Email("user@example.com")
+	m := &models.MemberOrg{
+		ID:              &id,
+		Email:           email,
+		InvitationState: "accepted",
+		Role:            &models.Role{Canonical: &role},
+		Username:        "john-doe",
+	}
+	var data organizationMemberResourceModel
+
+	diags := orgMemberCYModelToData("my-org", m, &data)
+
+	require.False(t, diags.HasError())
+	assert.Equal(t, "john-doe", data.MemberCanonical.ValueString())
+	assert.Equal(t, "user@example.com", data.Email.ValueString())
+	assert.Equal(t, int64(42), data.MemberId.ValueInt64())
+	assert.Equal(t, "organization-admin", data.RoleCanonical.ValueString())
+}
+
+// Pending invitations have no Username yet — member_canonical is empty until the invite is accepted.
+func TestOrgMemberCYModelToData_PendingInvite(t *testing.T) {
+	id := uint32(7)
+	role := "default-no-permissions"
+	inviteEmail := strfmt.Email("invite@example.com")
+	m := &models.MemberOrg{
+		ID:              &id,
+		InvitationEmail: inviteEmail,
+		InvitationState: "pending",
+		Role:            &models.Role{Canonical: &role},
+		Username:        "",
+	}
+	var data organizationMemberResourceModel
+
+	diags := orgMemberCYModelToData("my-org", m, &data)
+
+	require.False(t, diags.HasError())
+	assert.Equal(t, "", data.MemberCanonical.ValueString())
+	assert.Equal(t, types.StringValue(""), data.MemberCanonical)
+	assert.Equal(t, "invite@example.com", data.Email.ValueString())
+}
 
 func TestAccOrganizationMemberResource(t *testing.T) {
 	t.Parallel()
@@ -29,6 +80,8 @@ func TestAccOrganizationMemberResource(t *testing.T) {
 					resource.TestCheckResourceAttr("cycloid_organization_member.test", "organization_canonical", orgCanonical),
 					resource.TestCheckResourceAttr("cycloid_organization_member.test", "email", memberEmail),
 					resource.TestCheckResourceAttr("cycloid_organization_member.test", "role_canonical", roleCanonical),
+					// Pending invitations have no username yet; member_canonical is empty until accepted.
+					resource.TestCheckResourceAttr("cycloid_organization_member.test", "member_canonical", ""),
 				),
 			},
 			// Destroy testing

--- a/resource_organization_member/organization_member_resource_gen.go
+++ b/resource_organization_member/organization_member_resource_gen.go
@@ -26,6 +26,11 @@ func OrganizationMemberResourceSchema(ctx context.Context) schema.Schema {
 					),
 				},
 			},
+			"member_canonical": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The canonical (username) of the member.",
+				MarkdownDescription: "The canonical (username) of the member.",
+			},
 			"member_id": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
@@ -57,6 +62,7 @@ func OrganizationMemberResourceSchema(ctx context.Context) schema.Schema {
 
 type OrganizationMemberModel struct {
 	Email                 types.String `tfsdk:"email"`
+	MemberCanonical       types.String `tfsdk:"member_canonical"`
 	MemberId              types.Int64  `tfsdk:"member_id"`
 	OrganizationCanonical types.String `tfsdk:"organization_canonical"`
 	RoleCanonical         types.String `tfsdk:"role_canonical"`


### PR DESCRIPTION
## Summary

Closes OPS-1501.

- Adds `member_canonical` as a computed `String` attribute on the `cycloid_organization_member` resource
- The value is populated from `MemberOrg.Username` returned by the API (same field already used by the `cycloid_organization_members` data source)
- No breaking changes — existing configurations are unaffected; `member_canonical` is purely a new output

## Usage

After apply, the canonical can be referenced as:

```terraform
resource "cycloid_organization_member" "example" {
  email          = "user@example.com"
  role_canonical = "organization-member"
}

output "member_canonical" {
  value = cycloid_organization_member.example.member_canonical
}
```

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Existing unit tests pass (`go test ./provider/ -run TestOrgMembers`)
- [ ] Acceptance test against a real Cycloid org confirms `member_canonical` is populated after `terraform apply`

https://claude.ai/code/session_01EwAHMnNGFK5XqWUesFMGBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwAHMnNGFK5XqWUesFMGBd)_