### PR TITLE
fix(organization_role): clear scoped resources when omitted in HCL (TFPRO-42)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ To test the provider with Terraform, create a dev override file (see `README.md`
 - Acceptance tests run against the **local** docker-compose backend (`just be-start`), not remote staging — never point them at production. They need `CY_SAAS_API_KEY` (mints `.env`) + `API_LICENCE_KEY`.
 - `golangci-lint run ./...` is the lint gate (CI runs it); keep it clean.
 - Unit tests (`go test ./... -short`) may show `TestAccEnvironmentResource` as FAIL — a pre-existing bug where the test doesn't skip in non-acceptance mode. Use `just test-unit` and ignore that single failure, or `-run 'Test[^A]|TestA[^c]'`.
+- Never set `Computed: true` on a `List`/`Set`/`Map` attribute meant to be cleared by omission (scoped resources, tags, permissions, …) — see [DEVELOPING_TIPS.md § Never mark a "collection of things to configure" as Optional + Computed](DEVELOPING_TIPS.md#never-mark-a-collection-of-things-to-configure-as-optional--computed) before adding a new list/set/map attribute to any schema. Shipped twice already (TFPRO-42, `cycloid_organization_api_key`).
 
 <!-- gitnexus:start -->
 

--- a/DEVELOPING_TIPS.md
+++ b/DEVELOPING_TIPS.md
@@ -137,6 +137,59 @@ types.ListValueFrom(ctx, basetypes.ObjectType{AttrTypes: techType}, elems)
 types.ListValueFrom(ctx, datasource_stacks.TechnologiesType{ObjectType: types.ObjectType{AttrTypes: techType}}, elems)
 ```
 
+### Never mark a "collection of things to configure" as Optional + Computed
+
+If a `List`/`Set`/`Map` attribute represents something the user should be able to
+**clear by omitting it** (scoped resources, tags, allowed IPs, permissions — anything
+where "not in my HCL" should mean "empty at the API"), do not add `Computed` to it.
+
+`Optional + Computed` tells the framework: "if the user omits this, keep whatever is
+already in state." That's correct for a genuinely server-defaulted scalar (`canonical`
+auto-derived from `name`, `organization` defaulting to the provider's default org). It
+is a bug for a collection, because it means removing the block from HCL is silently
+indistinguishable from not touching it — the stale value gets sent back to the API on
+every apply, forever, and the user has no way to actually clear it short of knowing to
+write `attr = []` instead of deleting the line. Worse, if the attribute is nested
+inside a list/set that itself has a `RequiresReplace`-on-any-change plan modifier, the
+Computed retention happens at the leaf *before* that outer modifier ever compares
+anything — so `terraform plan` reports **zero changes** even though the user edited
+their config.
+
+This exact bug shipped twice (`cycloid_organization_role.rules[].resources`, TFPRO-42;
+`cycloid_organization_api_key.rules[].resources`, same root cause, fixed in the same
+PR) before being generalized here.
+
+```go
+// Bad — omitting `resources` in a rule silently retains the old value forever
+"resources": schema.ListAttribute{
+    Optional: true,
+    Computed: true,
+    ElementType: types.StringType,
+},
+
+// Good — Optional only; omission now plans as null, which the conversion layer
+// (see organizationRoleCYModelToData / apiKeyCYModelToData) coerces to an
+// explicit empty list before sending to the API
+"resources": schema.ListAttribute{
+    Optional: true,
+    ElementType: types.StringType,
+},
+```
+
+Dropping `Computed` introduces a **new** consistency requirement: the framework now
+expects the post-apply state to match the config exactly (null stays null, `[]` stays
+`[]`). If the backend API doesn't distinguish "no resources" from "never had
+resources" in its response, your model-conversion function must preserve whichever
+form the user actually configured — see `organizationRoleCYModelToData` and
+`apiKeyCYModelToData` for the pattern (look up the prior plan/state value per element
+before deciding what to write into state), and always send an explicit `[]` rather
+than a nil slice (JSON `null`) on the request side — that's what actually clears the
+field at the API; `null` may not.
+
+`environment_resource_schema.go`'s `variables` and `cloud_account_canonicals`
+(`Optional` only, no `Computed`, PATCH semantics spelled out in the description) are a
+clean reference example of doing this right from the start.
+
 ______________________________________________________________________
 
 ## Dev tooling

--- a/docs/resources/organization_api_key.md
+++ b/docs/resources/organization_api_key.md
@@ -136,7 +136,7 @@ Required:
 
 Optional:
 
-- `resources` (List of String) The list of resources this rule applies to.
+- `resources` (List of String) The list of resources this rule applies to. Omit or set to `[]` to make the rule apply globally; omitting it on a rules change clears any previously scoped resources.
 
 
 

--- a/docs/resources/organization_role.md
+++ b/docs/resources/organization_role.md
@@ -63,4 +63,4 @@ Required:
 Optional:
 
 - `effect` (String) Rule effect. Only `allow` is supported.
-- `resources` (List of String) Resources where this action applies.
+- `resources` (List of String) Resources where this action applies. Omit or set to `[]` to make the rule apply globally; omitting it on update clears any previously scoped resources.

--- a/provider/organization_api_key_resource.go
+++ b/provider/organization_api_key_resource.go
@@ -213,7 +213,28 @@ func apiKeyCYModelToData(ctx context.Context, org string, apiKey *models.APIKey,
 		data.Token = types.StringValue(apiKey.Token)
 	}
 
-	rules, rDiags := rulesToTFList(ctx, apiKey.Rules)
+	// Preserve the user's empty-representation for resources (same class of bug
+	// as TFPRO-42 / organization_role): the API returns an empty list whether the
+	// user wrote `resources = []` or omitted it entirely, but since resources is
+	// Optional (not Computed) the framework requires the post-apply state to
+	// match config exactly. Capture the planned/prior value per action so a rule
+	// that is empty on the API keeps the null-vs-[] form the user wrote, while
+	// genuine drift (API has resources) still surfaces. data.Rules still holds
+	// the plan (Create/Update) or prior state (Read) value at this point, since
+	// it hasn't been overwritten yet.
+	priorResources := map[string]types.List{}
+	if !data.Rules.IsNull() && !data.Rules.IsUnknown() {
+		var priorRules []resource_organization_api_key.RuleModel
+		diags.Append(data.Rules.ElementsAs(ctx, &priorRules, false)...)
+		if diags.HasError() {
+			return diags
+		}
+		for _, pr := range priorRules {
+			priorResources[pr.Action.ValueString()] = pr.Resources
+		}
+	}
+
+	rules, rDiags := rulesToTFList(ctx, apiKey.Rules, priorResources)
 	diags.Append(rDiags...)
 	if !diags.HasError() {
 		data.Rules = rules
@@ -236,7 +257,10 @@ func dataToNewRules(ctx context.Context, rulesVal types.List) ([]*models.NewRule
 	for i, rm := range ruleModels {
 		action := rm.Action.ValueString()
 		effect := rm.Effect.ValueString()
-		var resources []string
+		// Always send an explicit [] rather than JSON null, whether resources is
+		// omitted or empty in config — this is what actually clears scoped
+		// resources at the API (confirmed by the organization_role/TFPRO-42 fix).
+		resources := []string{}
 		if !rm.Resources.IsNull() && !rm.Resources.IsUnknown() {
 			diags.Append(rm.Resources.ElementsAs(ctx, &resources, false)...)
 			if diags.HasError() {
@@ -253,8 +277,10 @@ func dataToNewRules(ctx context.Context, rulesVal types.List) ([]*models.NewRule
 	return rules, diags
 }
 
-// rulesToTFList converts the API Rule slice to a Terraform types.List.
-func rulesToTFList(ctx context.Context, rules []*models.Rule) (types.List, diag.Diagnostics) {
+// rulesToTFList converts the API Rule slice to a Terraform types.List. priorResources
+// maps action -> the rule's resources value already in the plan/prior state, used to
+// preserve the user's null-vs-[] representation when the API reports no resources.
+func rulesToTFList(ctx context.Context, rules []*models.Rule, priorResources map[string]types.List) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	ruleModels := make([]resource_organization_api_key.RuleModel, len(rules))
@@ -269,7 +295,12 @@ func rulesToTFList(ctx context.Context, rules []*models.Rule) (types.List, diag.
 		}
 
 		var resourcesList types.List
-		if len(r.Resources) > 0 {
+		if prior, ok := priorResources[action]; len(r.Resources) == 0 && ok &&
+			!prior.IsUnknown() && (prior.IsNull() || len(prior.Elements()) == 0) {
+			// API has no resources for this rule and the user wrote null or [] —
+			// keep exactly what they configured to satisfy the consistency check.
+			resourcesList = prior
+		} else if len(r.Resources) > 0 {
 			var lDiags diag.Diagnostics
 			resourcesList, lDiags = types.ListValueFrom(ctx, types.StringType, r.Resources)
 			diags.Append(lDiags...)

--- a/provider/organization_api_key_resource_test.go
+++ b/provider/organization_api_key_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_organization_api_key"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,31 @@ import (
 )
 
 // Unit tests — no TF_ACC required.
+
+func mkRulesList(t *testing.T, ctx context.Context, rules []resource_organization_api_key.RuleModel) types.List {
+	t.Helper()
+	vals := make([]attr.Value, 0, len(rules))
+	for _, r := range rules {
+		obj, d := types.ObjectValueFrom(ctx, apiKeyRuleObjectType().(types.ObjectType).AttrTypes, r)
+		require.False(t, d.HasError(), "ObjectValueFrom: %v", d)
+		vals = append(vals, obj)
+	}
+	list, d := types.ListValue(apiKeyRuleObjectType(), vals)
+	require.False(t, d.HasError(), "ListValue: %v", d)
+	return list
+}
+
+func apiKeyStrListNull() types.List { return types.ListNull(types.StringType) }
+
+func apiKeyStrList(t *testing.T, ctx context.Context, elems ...string) types.List {
+	t.Helper()
+	if elems == nil {
+		elems = []string{}
+	}
+	l, d := types.ListValueFrom(ctx, types.StringType, elems)
+	require.False(t, d.HasError(), "ListValueFrom: %v", d)
+	return l
+}
 
 func TestAPIKeyCYModelToData_WithToken(t *testing.T) {
 	canonical := "my-api-key"
@@ -124,4 +150,89 @@ func TestDataToNewRules_Empty(t *testing.T) {
 	rules, rDiags := dataToNewRules(ctx, rulesVal)
 	require.False(t, rDiags.HasError())
 	assert.Empty(t, rules)
+}
+
+// TestDataToNewRules_ResourcesAlwaysExplicit is the organization_api_key
+// counterpart of TestOrganizationRolePlanRulesToCYModel_ResourcesAlwaysExplicit
+// (TFPRO-42): omitted or explicit-[] resources must both send an explicit []
+// to the API, never a nil/JSON-null Resources field.
+func TestDataToNewRules_ResourcesAlwaysExplicit(t *testing.T) {
+	ctx := context.Background()
+
+	rulesVal := mkRulesList(t, ctx, []resource_organization_api_key.RuleModel{
+		{Action: types.StringValue("organization:project:read"), Effect: types.StringValue("allow"), Resources: apiKeyStrListNull()},
+		{Action: types.StringValue("organization:team:read"), Effect: types.StringValue("allow"), Resources: apiKeyStrList(t, ctx)},
+		{Action: types.StringValue("organization:credential:read"), Effect: types.StringValue("allow"), Resources: apiKeyStrList(t, ctx, "organization:myorg:project:myproject")},
+	})
+
+	cyRules, diags := dataToNewRules(ctx, rulesVal)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Len(t, cyRules, 3)
+
+	byAction := map[string]*models.NewRule{}
+	for _, r := range cyRules {
+		require.NotNil(t, r.Resources, "Resources must never be nil — an explicit [] is required to clear API state")
+		byAction[*r.Action] = r
+	}
+
+	omitted := byAction["organization:project:read"]
+	require.NotNil(t, omitted)
+	assert.Equal(t, []string{}, omitted.Resources)
+
+	empty := byAction["organization:team:read"]
+	require.NotNil(t, empty)
+	assert.Equal(t, []string{}, empty.Resources)
+
+	scoped := byAction["organization:credential:read"]
+	require.NotNil(t, scoped)
+	assert.Equal(t, []string{"organization:myorg:project:myproject"}, scoped.Resources)
+}
+
+// TestAPIKeyCYModelToData_PreservesEmptyRepresentation is the
+// organization_api_key counterpart of
+// TestOrganizationRoleCYModelToData_PreservesEmptyRepresentation (TFPRO-42):
+// when the API reports a rule has no resources, the state must keep whichever
+// null-vs-[] form the user configured, not collapse both to the same thing.
+func TestAPIKeyCYModelToData_PreservesEmptyRepresentation(t *testing.T) {
+	ctx := context.Background()
+
+	data := organizationAPIKeyResourceModel{
+		Canonical: types.StringValue("my-api-key"),
+		Rules: mkRulesList(t, ctx, []resource_organization_api_key.RuleModel{
+			{Action: types.StringValue("act:omitted"), Effect: types.StringValue("allow"), Resources: apiKeyStrListNull()},
+			{Action: types.StringValue("act:empty"), Effect: types.StringValue("allow"), Resources: apiKeyStrList(t, ctx)},
+			{Action: types.StringValue("act:scoped"), Effect: types.StringValue("allow"), Resources: apiKeyStrList(t, ctx, "organization:o:project:p")},
+		}),
+	}
+
+	apiKey := &models.APIKey{
+		Canonical: strPtr("my-api-key"),
+		Name:      strPtr("My API Key"),
+		Rules: []*models.Rule{
+			{Action: strPtr("act:omitted"), Effect: strPtr("allow"), Resources: nil},
+			{Action: strPtr("act:empty"), Effect: strPtr("allow"), Resources: []string{}},
+			{Action: strPtr("act:scoped"), Effect: strPtr("allow"), Resources: []string{"organization:o:project:p"}},
+		},
+	}
+
+	diags := apiKeyCYModelToData(ctx, "my-org", apiKey, &data)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+
+	var stateRules []resource_organization_api_key.RuleModel
+	diags = data.Rules.ElementsAs(ctx, &stateRules, false)
+	require.False(t, diags.HasError(), "ElementsAs: %v", diags)
+
+	byAction := map[string]resource_organization_api_key.RuleModel{}
+	for _, r := range stateRules {
+		byAction[r.Action.ValueString()] = r
+	}
+
+	assert.True(t, byAction["act:omitted"].Resources.IsNull(),
+		"omitted resources must remain null to match config")
+
+	emptyRes := byAction["act:empty"].Resources
+	assert.False(t, emptyRes.IsNull(), "explicit [] must remain a non-null empty list")
+	assert.Len(t, emptyRes.Elements(), 0)
+
+	assert.Len(t, byAction["act:scoped"].Resources.Elements(), 1)
 }

--- a/provider/organization_role_resource.go
+++ b/provider/organization_role_resource.go
@@ -273,6 +273,25 @@ func organizationRoleCYModelToData(ctx context.Context, org string, role *models
 	var diags diag.Diagnostics
 
 	ruleObjectType := types.ObjectType{AttrTypes: resource_organization_role.OrganizationRoleRuleTypes}
+
+	// Preserve the user's empty-representation for resources. The API returns an
+	// empty list whether the user wrote `resources = []` or omitted it entirely,
+	// but since resources is Optional (not Computed) the framework requires the
+	// post-apply state to match config exactly. Capture the planned/prior value
+	// per action so a rule that is empty on the API keeps the null-vs-[] form the
+	// user wrote, while genuine drift (API has resources) still surfaces.
+	priorResources := map[string]types.List{}
+	if !roleState.Rules.IsNull() && !roleState.Rules.IsUnknown() {
+		var priorRules []organizationRoleRuleResourceModel
+		diags.Append(roleState.Rules.ElementsAs(ctx, &priorRules, false)...)
+		if diags.HasError() {
+			return diags
+		}
+		for _, pr := range priorRules {
+			priorResources[pr.Action.ValueString()] = pr.Resources
+		}
+	}
+
 	if role == nil {
 		roleState.Name = types.StringNull()
 		roleState.Canonical = types.StringNull()
@@ -290,10 +309,19 @@ func organizationRoleCYModelToData(ctx context.Context, org string, role *models
 			continue
 		}
 
-		resourcesList, resourcesDiags := types.ListValueFrom(ctx, types.StringType, roleRule.Resources)
-		diags.Append(resourcesDiags...)
-		if diags.HasError() {
-			return diags
+		var resourcesList types.List
+		if prior, ok := priorResources[ptr.Value(roleRule.Action)]; len(roleRule.Resources) == 0 && ok &&
+			!prior.IsUnknown() && (prior.IsNull() || len(prior.Elements()) == 0) {
+			// API has no resources for this rule and the user wrote null or [] —
+			// keep exactly what they configured to satisfy the consistency check.
+			resourcesList = prior
+		} else {
+			var resourcesDiags diag.Diagnostics
+			resourcesList, resourcesDiags = types.ListValueFrom(ctx, types.StringType, roleRule.Resources)
+			diags.Append(resourcesDiags...)
+			if diags.HasError() {
+				return diags
+			}
 		}
 
 		effect := ptr.Value(roleRule.Effect)

--- a/provider/organization_role_resource_test.go
+++ b/provider/organization_role_resource_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/resource_organization_role"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+// mkRulesSet builds a rules Set from a slice of rule models, mirroring how the
+// Terraform framework would populate the plan/state.
+func mkRulesSet(t *testing.T, ctx context.Context, rules []organizationRoleRuleResourceModel) types.Set {
+	t.Helper()
+	ruleObjectType := types.ObjectType{AttrTypes: resource_organization_role.OrganizationRoleRuleTypes}
+	vals := make([]attr.Value, 0, len(rules))
+	for _, r := range rules {
+		obj, d := types.ObjectValueFrom(ctx, resource_organization_role.OrganizationRoleRuleTypes, r)
+		require.False(t, d.HasError(), "ObjectValueFrom: %v", d)
+		vals = append(vals, obj)
+	}
+	set, d := types.SetValue(ruleObjectType, vals)
+	require.False(t, d.HasError(), "SetValue: %v", d)
+	return set
+}
+
+func strListNull() types.List { return types.ListNull(types.StringType) }
+
+func strList(t *testing.T, ctx context.Context, elems ...string) types.List {
+	t.Helper()
+	if elems == nil {
+		// A zero-arg variadic call yields a nil slice, which reflects to a null
+		// list. `resources = []` in HCL is a non-null empty list, so force that.
+		elems = []string{}
+	}
+	l, d := types.ListValueFrom(ctx, types.StringType, elems)
+	require.False(t, d.HasError(), "ListValueFrom: %v", d)
+	return l
+}
+
+// TestOrganizationRolePlanRulesToCYModel_ResourcesAlwaysExplicit is the core
+// regression for TFPRO-42: whether the user omits `resources` (null) or sets it
+// to `[]`, the request body sent to the API must carry an explicit empty list so
+// the API clears any previously scoped resources rather than treating the field
+// as "no change".
+func TestOrganizationRolePlanRulesToCYModel_ResourcesAlwaysExplicit(t *testing.T) {
+	ctx := context.Background()
+
+	rules := mkRulesSet(t, ctx, []organizationRoleRuleResourceModel{
+		{Action: types.StringValue("organization:project:*"), Effect: types.StringNull(), Resources: strListNull()},
+		{Action: types.StringValue("organization:team:*"), Effect: types.StringValue("allow"), Resources: strList(t, ctx)},
+		{Action: types.StringValue("organization:credential:read"), Effect: types.StringNull(), Resources: strList(t, ctx, "organization:myorg:project:myproject")},
+	})
+
+	cyRules, diags := organizationRolePlanRulesToCYModel(ctx, rules)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+	require.Len(t, cyRules, 3)
+
+	byAction := map[string]*models.NewRule{}
+	for _, r := range cyRules {
+		require.NotNil(t, r.Resources, "Resources must never be nil — an explicit [] is required to clear API state")
+		byAction[*r.Action] = r
+	}
+
+	// Omitted (null) resources -> explicit empty list, effect defaulted to allow.
+	omitted := byAction["organization:project:*"]
+	require.NotNil(t, omitted)
+	require.Equal(t, []string{}, omitted.Resources)
+	require.Equal(t, "allow", *omitted.Effect)
+
+	// Explicit [] resources -> explicit empty list.
+	empty := byAction["organization:team:*"]
+	require.NotNil(t, empty)
+	require.Equal(t, []string{}, empty.Resources)
+
+	// Populated resources -> passed through unchanged.
+	scoped := byAction["organization:credential:read"]
+	require.NotNil(t, scoped)
+	require.Equal(t, []string{"organization:myorg:project:myproject"}, scoped.Resources)
+}
+
+// TestOrganizationRoleCYModelToData_PreservesEmptyRepresentation verifies that
+// because `resources` is Optional (not Computed), the state written back keeps
+// the exact null-vs-[] form the user configured when the API reports the rule
+// has no scoped resources. Otherwise Terraform raises "provider produced
+// inconsistent result after apply".
+func TestOrganizationRoleCYModelToData_PreservesEmptyRepresentation(t *testing.T) {
+	ctx := context.Background()
+
+	plan := organizationRoleResourceModel{
+		Canonical: types.StringValue("my-role"),
+		Rules: mkRulesSet(t, ctx, []organizationRoleRuleResourceModel{
+			{Action: types.StringValue("act:omitted"), Effect: types.StringValue("allow"), Resources: strListNull()},
+			{Action: types.StringValue("act:empty"), Effect: types.StringValue("allow"), Resources: strList(t, ctx)},
+			{Action: types.StringValue("act:scoped"), Effect: types.StringValue("allow"), Resources: strList(t, ctx, "organization:o:project:p")},
+		}),
+	}
+
+	role := &models.Role{
+		Name:      strPtr("My Role"),
+		Canonical: strPtr("my-role"),
+		Rules: []*models.Rule{
+			{Action: strPtr("act:omitted"), Effect: strPtr("allow"), Resources: nil},
+			{Action: strPtr("act:empty"), Effect: strPtr("allow"), Resources: []string{}},
+			{Action: strPtr("act:scoped"), Effect: strPtr("allow"), Resources: []string{"organization:o:project:p"}},
+		},
+	}
+
+	diags := organizationRoleCYModelToData(ctx, "my-org", role, &plan)
+	require.False(t, diags.HasError(), "diags: %v", diags)
+
+	var stateRules []organizationRoleRuleResourceModel
+	diags = plan.Rules.ElementsAs(ctx, &stateRules, false)
+	require.False(t, diags.HasError(), "ElementsAs: %v", diags)
+
+	byAction := map[string]organizationRoleRuleResourceModel{}
+	for _, r := range stateRules {
+		byAction[r.Action.ValueString()] = r
+	}
+
+	// Omitted in config + empty on API -> stays null.
+	require.True(t, byAction["act:omitted"].Resources.IsNull(),
+		"omitted resources must remain null to match config")
+
+	// Explicit [] in config + empty on API -> stays an empty (non-null) list.
+	emptyRes := byAction["act:empty"].Resources
+	require.False(t, emptyRes.IsNull(), "explicit [] must remain a non-null empty list")
+	require.Len(t, emptyRes.Elements(), 0)
+
+	// Scoped resources on API -> surfaced regardless of prior representation.
+	require.Len(t, byAction["act:scoped"].Resources.Elements(), 1)
+}

--- a/resource_organization_api_key/organization_api_key_resource_gen.go
+++ b/resource_organization_api_key/organization_api_key_resource_gen.go
@@ -86,10 +86,9 @@ func OrganizationAPIKeyResourceSchema(ctx context.Context) schema.Schema {
 						},
 						"resources": schema.ListAttribute{
 							Optional:            true,
-							Computed:            true,
 							ElementType:         types.StringType,
-							Description:         "The list of resources this rule applies to.",
-							MarkdownDescription: "The list of resources this rule applies to.",
+							Description:         "The list of resources this rule applies to. Omit or set to `[]` to make the rule apply globally; omitting it on a rules change clears any previously scoped resources.",
+							MarkdownDescription: "The list of resources this rule applies to. Omit or set to `[]` to make the rule apply globally; omitting it on a rules change clears any previously scoped resources.",
 						},
 					},
 				},

--- a/resource_organization_role/organization_role_schema.go
+++ b/resource_organization_role/organization_role_schema.go
@@ -87,11 +87,10 @@ func OrganizationRoleResourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 						"resources": schema.ListAttribute{
-							Description:         "Resources where this action applies.",
-							MarkdownDescription: "Resources where this action applies.",
+							Description:         "Resources where this action applies. Omit or set to `[]` to make the rule apply globally; omitting it on update clears any previously scoped resources.",
+							MarkdownDescription: "Resources where this action applies. Omit or set to `[]` to make the rule apply globally; omitting it on update clears any previously scoped resources.",
 							ElementType:         types.StringType,
 							Optional:            true,
-							Computed:            true,
 						},
 					},
 				},


### PR DESCRIPTION
## What

Fixes [TFPRO-42](https://linear.app/cycloid/issue/TFPRO-42) / closes #103.

Omitting `resources` from a `cycloid_organization_role` rule did **not** clear previously scoped resources on update — the API kept the old list. Reported by DIGIT/ARHS (Nicolas Labrot).

## Root cause

The `resources` rule attribute was `Optional + Computed`. In terraform-plugin-framework, an Optional+Computed attribute that is omitted in config takes its **prior state value** as the planned value (to avoid perpetual diffs on server-side defaults). So removing `resources` read as "no change", and the old scoped resources were sent back to the API.

`NewRule.Resources` has no `omitempty`, and the explicit `resources = []` workaround already cleared correctly — confirming the bug is purely plan-time Computed retention.

## Fix

- **Drop `Computed`** from `resources` (Optional only). Omission now plans as null, which the existing conversion already coerces to an explicit `[]` → API clears the resources.
- Dropping Computed introduces the null-vs-empty **post-apply consistency check**. The state mapper (`organizationRoleCYModelToData`) now preserves the exact form the user configured (`null` vs `[]`) when the API reports a rule has no resources — so both omission and the `resources = []` workaround stay consistent — while genuine drift (API has resources) still surfaces.
- Updated the attribute description + regenerated docs.

## Tests

Two unit tests (`provider/organization_role_resource_test.go`):
- `TestOrganizationRolePlanRulesToCYModel_ResourcesAlwaysExplicit` — omitted/`[]`/populated all produce a non-nil `Resources` slice in the API payload.
- `TestOrganizationRoleCYModelToData_PreservesEmptyRepresentation` — empty-on-API keeps the configured null-vs-`[]` form; scoped resources surface.

---

## Update: same bug found + fixed in `cycloid_organization_api_key` (just-merged #106)

Audited every `Optional+Computed` `List`/`Set`/`Map` attribute in the provider after landing the fix above. Found the identical bug in `cycloid_organization_api_key`'s `rules[].resources` — same underlying `NewRule`/`Rule` model as `organization_role`.

**This instance is worse than the original.** `organization_api_key`'s `rules` list has a custom `RequiresReplace`-on-any-change plan modifier. Optional+Computed retention happens per nested leaf *during planning*, before that outer modifier ever gets to compare anything — so `terraform plan` reported **zero changes** even though the user edited their config to remove `resources` from a rule. At least the original bug produced a (wrong) apply; this one produced no plan at all.

Fix mirrors this PR's `organization_role` fix exactly (drop `Computed`, always send explicit `[]` on the request side, preserve null-vs-`[]` representation on the response side). New tests: `TestDataToNewRules_ResourcesAlwaysExplicit`, `TestAPIKeyCYModelToData_PreservesEmptyRepresentation` — both verified failing against pre-fix code with the expected symptoms, then green after.

**Documented so a third resource doesn't ship this:** added a "Never mark a collection of things to configure as Optional + Computed" section to `DEVELOPING_TIPS.md` with the Bad/Good pattern and the reasoning above, cross-referenced from `AGENTS.md`'s Gotchas list.

**Found but not fixed here (flagging for a follow-up):** `credential.body.raw` (the `type = "custom"` map) has a narrower variant of the same issue — only reachable if a user stays on `type = "custom"` and fully omits `raw` to clear all fields, rather than writing `raw = {}` (switching `type` away from `"custom"` already correctly nulls it regardless). Different resource/model shape, much rarer path — didn't fold it into this PR, but it's the next candidate if this class of bug needs a full sweep.

**Positive reference already in the codebase:** `environment_resource_schema.go` / `organization_environment_resource_schema.go`'s `variables` and `cloud_account_canonicals` already do this correctly (`Optional` only, PATCH semantics spelled out in the description) — cited as the pattern to follow in the new docs.

🤖 Generated with a fleet worker session — https://claude.ai/code/session_014CST9mw3ABSA4aYHNy96EV
