### PR TITLE
fix(plugin): guard nil UUID in pluginInstallToModel (ENG-183)

### DIFF
--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -249,7 +249,14 @@ func mergePluginConfiguration(ctx context.Context, data pluginResourceModel) (ma
 func pluginInstallToModel(org string, install *models.PluginInstall, data *pluginResourceModel) {
 	data.Organization = types.StringValue(org)
 	data.ID = types.Int64Value(int64(ptr.Value(install.ID)))
-	data.UUID = types.StringValue(install.UUID.String())
+	// uuid is Required in the swagger contract but the GET/refresh response may
+	// omit it (it is populated on the create response only). A nil *strfmt.UUID
+	// would panic on .String() — preserve whatever is already in state instead of
+	// crashing or overwriting it with an empty value (same rationale as the
+	// configuration preservation at the Read call site).
+	if install.UUID != nil {
+		data.UUID = types.StringValue(install.UUID.String())
+	}
 	data.Status = types.StringPointerValue(install.Status)
 	data.CreatedAt = types.Int64Value(int64(ptr.Value(install.CreatedAt)))
 	data.UpdatedAt = types.Int64Value(int64(ptr.Value(install.UpdatedAt)))
@@ -258,4 +265,3 @@ func pluginInstallToModel(org string, install *models.PluginInstall, data *plugi
 		data.PluginVersionID = types.Int64Value(int64(ptr.Value(install.Version.ID)))
 	}
 }
-

--- a/provider/plugin_resource_unit_test.go
+++ b/provider/plugin_resource_unit_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/internal/ptr"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestPluginInstallToModel_NilFields is the regression test for ENG-183:
+// the provider crashed with a SIGSEGV in pluginInstallToModel because the
+// GET/refresh response returns a PluginInstall whose UUID (*strfmt.UUID) is
+// nil, and install.UUID.String() dereferenced the nil pointer.
+//
+// pluginInstallToModel must not panic on any nil field, and must preserve the
+// UUID already present in state when the API omits it.
+func TestPluginInstallToModel_NilFields(t *testing.T) {
+	// data simulates prior state from a successful create — UUID is populated.
+	data := pluginResourceModel{
+		UUID: types.StringValue("11111111-1111-1111-1111-111111111111"),
+	}
+
+	// install simulates the refresh GET response: required-in-swagger fields
+	// come back nil/zero, mirroring the production crash on DIGIT.
+	install := &models.PluginInstall{
+		ID:        ptr.Ptr(uint32(42)),
+		UUID:      nil, // <- the field that caused the panic
+		Status:    nil,
+		CreatedAt: nil,
+		UpdatedAt: nil,
+		Version:   nil,
+	}
+
+	// Must not panic.
+	pluginInstallToModel("my-org", install, &data)
+
+	if got := data.Organization.ValueString(); got != "my-org" {
+		t.Errorf("Organization: got %q, want %q", got, "my-org")
+	}
+	if got := data.ID.ValueInt64(); got != 42 {
+		t.Errorf("ID: got %d, want 42", got)
+	}
+	// UUID omitted by the API → preserved from prior state, not blanked.
+	if got := data.UUID.ValueString(); got != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("UUID: got %q, want preserved-from-state value", got)
+	}
+	// Nil pointer fields degrade to their zero values without panicking.
+	if got := data.CreatedAt.ValueInt64(); got != 0 {
+		t.Errorf("CreatedAt: got %d, want 0", got)
+	}
+	if got := data.UpdatedAt.ValueInt64(); got != 0 {
+		t.Errorf("UpdatedAt: got %d, want 0", got)
+	}
+	if !data.Status.IsNull() {
+		t.Errorf("Status: got %v, want null", data.Status)
+	}
+}
+
+// TestPluginInstallToModel_FullyPopulated verifies the create/import path where
+// the API returns a fully populated install: every field is mapped through.
+func TestPluginInstallToModel_FullyPopulated(t *testing.T) {
+	uuid := strfmt.UUID("22222222-2222-2222-2222-222222222222")
+	data := pluginResourceModel{}
+
+	install := &models.PluginInstall{
+		ID:        ptr.Ptr(uint32(7)),
+		UUID:      &uuid,
+		Status:    ptr.Ptr("running"),
+		CreatedAt: ptr.Ptr(uint64(1000)),
+		UpdatedAt: ptr.Ptr(uint64(2000)),
+		Version:   &models.PluginVersion{ID: ptr.Ptr(uint32(99))},
+	}
+
+	pluginInstallToModel("org", install, &data)
+
+	if got := data.UUID.ValueString(); got != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("UUID: got %q, want populated value", got)
+	}
+	if got := data.Status.ValueString(); got != "running" {
+		t.Errorf("Status: got %q, want running", got)
+	}
+	if got := data.CreatedAt.ValueInt64(); got != 1000 {
+		t.Errorf("CreatedAt: got %d, want 1000", got)
+	}
+	if got := data.UpdatedAt.ValueInt64(); got != 2000 {
+		t.Errorf("UpdatedAt: got %d, want 2000", got)
+	}
+	if got := data.PluginVersionID.ValueInt64(); got != 99 {
+		t.Errorf("PluginVersionID: got %d, want 99", got)
+	}
+}


### PR DESCRIPTION
## Problem

The `cycloid_plugin` resource crashes with a SIGSEGV on plan/refresh after the first successful apply. Reported by DIGIT/ARHS (Trello, [ENG-183](https://linear.app/cycloid/issue/ENG-183/terraform-provider-is-crashing-on-plugin-resource)) — provider v0.6.2, Console/API v6.9.88.

```
panic: nil pointer dereference [signal SIGSEGV addr=0x8]
provider/plugin_resource.go:252 pluginInstallToModel
provider/plugin_resource.go:150 (*pluginResource).Read
```

## Root cause

`PluginInstall.UUID` is a `*strfmt.UUID`. Swagger marks it `Required`, but the **GET/refresh** response omits it — it's only populated on the **create** response. `install.UUID.String()` then dereferenced a nil pointer (`UUID.String()` has a value receiver, so the auto-deref panics).

First apply succeeds (create response fully populated); the subsequent plan's `Read` crashes. Verified against the cli middleware `GetPlugin` (deserializes raw API JSON via `GenericRequest`, no validation) and the `PluginInstall` swagger model (`v1.0.98-0.20260527`).

## Fix

Guard the UUID assignment: map it only when non-nil, otherwise **preserve the value already in state** — same rationale as the configuration preservation at the `Read` call site. The import path passes a fresh `data` struct, so UUID stays null there (acceptable, like configuration). The other fields were already nil-safe (`ptr.Value`, `StringPointerValue`, `Version != nil`).

## Test

Regression unit test feeds an install with nil `UUID/CreatedAt/UpdatedAt/Status/Version` → asserts no panic and that the state UUID is preserved. Plus a fully-populated case for the create/import path.

`go build ./...`, `go vet`, and the unit tests are green.

## Follow-up

A backport to the v0.6.x release line (v0.6.3) will follow in a separate PR — DIGIT runs v0.6.2 and won't jump versions.

Fixes ENG-183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)