### PR TITLE
fix(plugin): backport nil-UUID crash fix to v0.6.x → v0.6.3 (ENG-183)

### DIFF
--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -249,7 +249,14 @@ func mergePluginConfiguration(ctx context.Context, data pluginResourceModel) (ma
 func pluginInstallToModel(org string, install *models.PluginInstall, data *pluginResourceModel) {
 	data.Organization = types.StringValue(org)
 	data.ID = types.Int64Value(int64(ptr.Value(install.ID)))
-	data.UUID = types.StringValue(install.UUID.String())
+	// uuid is Required in the swagger contract but the GET/refresh response may
+	// omit it (it is populated on the create response only). A nil *strfmt.UUID
+	// would panic on .String() — preserve whatever is already in state instead of
+	// crashing or overwriting it with an empty value (same rationale as the
+	// configuration preservation at the Read call site).
+	if install.UUID != nil {
+		data.UUID = types.StringValue(install.UUID.String())
+	}
 	data.Status = types.StringPointerValue(install.Status)
 	data.CreatedAt = types.Int64Value(int64(ptr.Value(install.CreatedAt)))
 	data.UpdatedAt = types.Int64Value(int64(ptr.Value(install.UpdatedAt)))
@@ -258,4 +265,3 @@ func pluginInstallToModel(org string, install *models.PluginInstall, data *plugi
 		data.PluginVersionID = types.Int64Value(int64(ptr.Value(install.Version.ID)))
 	}
 }
-

--- a/provider/plugin_resource_unit_test.go
+++ b/provider/plugin_resource_unit_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/terraform-provider-cycloid/internal/ptr"
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestPluginInstallToModel_NilFields is the regression test for ENG-183:
+// the provider crashed with a SIGSEGV in pluginInstallToModel because the
+// GET/refresh response returns a PluginInstall whose UUID (*strfmt.UUID) is
+// nil, and install.UUID.String() dereferenced the nil pointer.
+//
+// pluginInstallToModel must not panic on any nil field, and must preserve the
+// UUID already present in state when the API omits it.
+func TestPluginInstallToModel_NilFields(t *testing.T) {
+	// data simulates prior state from a successful create — UUID is populated.
+	data := pluginResourceModel{
+		UUID: types.StringValue("11111111-1111-1111-1111-111111111111"),
+	}
+
+	// install simulates the refresh GET response: required-in-swagger fields
+	// come back nil/zero, mirroring the production crash on DIGIT.
+	install := &models.PluginInstall{
+		ID:        ptr.Ptr(uint32(42)),
+		UUID:      nil, // <- the field that caused the panic
+		Status:    nil,
+		CreatedAt: nil,
+		UpdatedAt: nil,
+		Version:   nil,
+	}
+
+	// Must not panic.
+	pluginInstallToModel("my-org", install, &data)
+
+	if got := data.Organization.ValueString(); got != "my-org" {
+		t.Errorf("Organization: got %q, want %q", got, "my-org")
+	}
+	if got := data.ID.ValueInt64(); got != 42 {
+		t.Errorf("ID: got %d, want 42", got)
+	}
+	// UUID omitted by the API → preserved from prior state, not blanked.
+	if got := data.UUID.ValueString(); got != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("UUID: got %q, want preserved-from-state value", got)
+	}
+	// Nil pointer fields degrade to their zero values without panicking.
+	if got := data.CreatedAt.ValueInt64(); got != 0 {
+		t.Errorf("CreatedAt: got %d, want 0", got)
+	}
+	if got := data.UpdatedAt.ValueInt64(); got != 0 {
+		t.Errorf("UpdatedAt: got %d, want 0", got)
+	}
+	if !data.Status.IsNull() {
+		t.Errorf("Status: got %v, want null", data.Status)
+	}
+}
+
+// TestPluginInstallToModel_FullyPopulated verifies the create/import path where
+// the API returns a fully populated install: every field is mapped through.
+func TestPluginInstallToModel_FullyPopulated(t *testing.T) {
+	uuid := strfmt.UUID("22222222-2222-2222-2222-222222222222")
+	data := pluginResourceModel{}
+
+	install := &models.PluginInstall{
+		ID:        ptr.Ptr(uint32(7)),
+		UUID:      &uuid,
+		Status:    ptr.Ptr("running"),
+		CreatedAt: ptr.Ptr(uint64(1000)),
+		UpdatedAt: ptr.Ptr(uint64(2000)),
+		Version:   &models.PluginVersion{ID: ptr.Ptr(uint32(99))},
+	}
+
+	pluginInstallToModel("org", install, &data)
+
+	if got := data.UUID.ValueString(); got != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("UUID: got %q, want populated value", got)
+	}
+	if got := data.Status.ValueString(); got != "running" {
+		t.Errorf("Status: got %q, want running", got)
+	}
+	if got := data.CreatedAt.ValueInt64(); got != 1000 {
+		t.Errorf("CreatedAt: got %d, want 1000", got)
+	}
+	if got := data.UpdatedAt.ValueInt64(); got != 2000 {
+		t.Errorf("UpdatedAt: got %d, want 2000", got)
+	}
+	if got := data.PluginVersionID.ValueInt64(); got != 99 {
+		t.Errorf("PluginVersionID: got %d, want 99", got)
+	}
+}


### PR DESCRIPTION
## Backport of #109 to the v0.6.x release line

DIGIT/ARHS run provider **v0.6.2** and won't jump to v0.7.x for a crash fix (requested by Nicolas). This backports the minimal nil-safety fix + regression test from #109 onto a `release/v0.6` maintenance branch (cut from tag `v0.6.2`) for a **v0.6.3** patch release.

## What

Cherry-pick of the single fix commit — `pluginInstallToModel` nil-UUID guard + regression unit test. No unrelated changes.

`pluginInstallToModel` at v0.6.2 was byte-identical to master's pre-fix version, so the cherry-pick applied cleanly. Verified `go build ./...`, `go vet`, and the unit tests are **green against the v0.6.2 base** (no env-model drift, unlike TFPRO-38).

## Root cause (see #109 for full detail)

`PluginInstall.UUID` (`*strfmt.UUID`) is omitted by the GET/refresh response despite being swagger-Required; `install.UUID.String()` dereferenced nil → SIGSEGV at `plugin_resource.go:252` during the second plan's `Read`.

## Release

Target branch `release/v0.6` was created off tag `v0.6.2` to host the 6.x maintenance line. After merge, tag **v0.6.3** off `release/v0.6`.

Relates to ENG-183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)