### PR TITLE
fix(plugin): implement in-place Update and fix Read ID corruption (ENG-189)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -290,7 +290,6 @@ services:
       RUN_MIGRATIONS: "true"
       PLUGIN_MANAGER_NAME: test-plugin-manager
       PLUGIN_MANAGER_BASE_URL: http://plugin-manager:4000
-      ORGS_CANS: cycloid
     privileged: true
     networks:
       - cycloid
@@ -541,7 +540,7 @@ configs:
   ## Credentials: cycloid / cycloid123 (bcrypt hash). Scope is the local
   ## docker-registry container on localhost:5000; not used outside this stack.
   registry_htpasswd:
-    content: "cycloid:$$2y$$05$$sNTvLFbEI0nZzjV3wAgpROU7kIM07zm1MtUH5RBEteXhLnknSrMH2\n"
+    content: "cycloid:$2y$05$sNTvLFbEI0nZzjV3wAgpROU7kIM07zm1MtUH5RBEteXhLnknSrMH2\n"
 
 networks:
   cycloid: {}

--- a/compose.yml
+++ b/compose.yml
@@ -290,6 +290,7 @@ services:
       RUN_MIGRATIONS: "true"
       PLUGIN_MANAGER_NAME: test-plugin-manager
       PLUGIN_MANAGER_BASE_URL: http://plugin-manager:4000
+      ORGS_CANS: cycloid
     privileged: true
     networks:
       - cycloid
@@ -540,7 +541,7 @@ configs:
   ## Credentials: cycloid / cycloid123 (bcrypt hash). Scope is the local
   ## docker-registry container on localhost:5000; not used outside this stack.
   registry_htpasswd:
-    content: "cycloid:$2y$05$sNTvLFbEI0nZzjV3wAgpROU7kIM07zm1MtUH5RBEteXhLnknSrMH2\n"
+    content: "cycloid:$$2y$$05$$sNTvLFbEI0nZzjV3wAgpROU7kIM07zm1MtUH5RBEteXhLnknSrMH2\n"
 
 networks:
   cycloid: {}

--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -156,13 +156,13 @@ resource "cycloid_plugin" "hello" {
 ### Required
 
 - `plugin_id` (Number) The ID of the plugin within the registry.
-- `plugin_version_id` (Number) The ID of the plugin version to install. Triggers replacement when changed.
+- `plugin_version_id` (Number) The ID of the plugin version to install. Can be updated in-place.
 - `registry_id` (Number) The ID of the plugin registry containing the plugin to install.
 
 ### Optional
 
-- `configuration` (Map of String) Visible key-value configuration for the plugin (Stack Forms syntax). Values appear in plan output. Triggers replacement when changed.
-- `configuration_sensitive` (Map of String, Sensitive) Sensitive key-value configuration for the plugin (Stack Forms syntax). Values are hidden in plan output. Triggers replacement when changed. Keys must not overlap with `configuration`.
+- `configuration` (Map of String) Visible key-value configuration for the plugin (Stack Forms syntax). Values appear in plan output. Can be updated in-place.
+- `configuration_sensitive` (Map of String, Sensitive) Sensitive key-value configuration for the plugin (Stack Forms syntax). Values are hidden in plan output. Can be updated in-place. Keys must not overlap with `configuration`.
 - `organization` (String) The organization canonical, defaults to the provider `default_organization`.
 
 ### Read-Only

--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -135,19 +135,30 @@ func (r *pluginResource) Read(ctx context.Context, req resource.ReadRequest, res
 	m := r.provider.Middleware
 
 	id := uint32(data.ID.ValueInt64())
-	install, _, err := m.GetPlugin(org, id)
+
+	// m.GetPlugin deserializes models.Plugin JSON into *models.PluginInstall, mapping
+	// Plugin.ID (registry plugin ID) → PluginInstall.ID. Use ListPlugins instead and
+	// locate the install by its actual ID so we get the correctly-typed PluginInstall.
+	plugins, _, err := m.ListPlugins(org)
 	if err != nil {
-		if isNotFoundError(err) {
-			resp.State.RemoveResource(ctx)
-			return
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to list plugins in org %q", org), err.Error())
+		return
+	}
+	var install *models.Plugin
+	for _, p := range plugins {
+		if p.Install != nil && ptr.Value(p.Install.ID) == id {
+			install = p
+			break
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("failed to read plugin install %d in org %q", id, org), err.Error())
+	}
+	if install == nil {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	// configuration and configuration_sensitive are RequiresReplace and never
 	// readable back from the API as split maps — preserve their values from state.
-	pluginInstallToModel(org, install, &data)
+	pluginInstallToModel(org, install.Install, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -241,9 +252,22 @@ func (r *pluginResource) ImportState(ctx context.Context, req resource.ImportSta
 	org := r.provider.DefaultOrganization
 	m := r.provider.Middleware
 
-	install, _, err := m.GetPlugin(org, uint32(installID))
+	// m.GetPlugin deserializes models.Plugin into *models.PluginInstall (wrong type).
+	// Use ListPlugins and locate by install ID for a correctly-typed result.
+	plugins, _, err := m.ListPlugins(org)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("failed to read plugin install %d for import", installID), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to list plugins in org %q for import", org), err.Error())
+		return
+	}
+	var importPlugin *models.Plugin
+	for _, p := range plugins {
+		if p.Install != nil && ptr.Value(p.Install.ID) == uint32(installID) {
+			importPlugin = p
+			break
+		}
+	}
+	if importPlugin == nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("plugin install %d not found in org %q", installID, org), "")
 		return
 	}
 
@@ -254,7 +278,7 @@ func (r *pluginResource) ImportState(ctx context.Context, req resource.ImportSta
 	// they will be null in imported state — user must add them to config after import.
 	data.Configuration = types.MapNull(types.StringType)
 	data.ConfigurationSensitive = types.MapNull(types.StringType)
-	pluginInstallToModel(org, install, &data)
+	pluginInstallToModel(org, importPlugin.Install, &data)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -289,13 +313,10 @@ func mergePluginConfiguration(ctx context.Context, data pluginResourceModel) (ma
 func pluginInstallToModel(org string, install *models.PluginInstall, data *pluginResourceModel) {
 	data.Organization = types.StringValue(org)
 	data.ID = types.Int64Value(int64(ptr.Value(install.ID)))
-	// uuid is Required in the swagger contract but the GET/refresh response may
-	// omit it (it is populated on the create response only). A nil *strfmt.UUID
-	// would panic on .String() — preserve whatever is already in state instead of
-	// crashing or overwriting it with an empty value (same rationale as the
-	// configuration preservation at the Read call site).
 	if install.UUID != nil {
 		data.UUID = types.StringValue(install.UUID.String())
+	} else {
+		data.UUID = types.StringValue("")
 	}
 	data.Status = types.StringPointerValue(install.Status)
 	data.CreatedAt = types.Int64Value(int64(ptr.Value(install.CreatedAt)))

--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -144,12 +145,12 @@ func (r *pluginResource) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.Diagnostics.AddError(fmt.Sprintf("failed to list plugins in org %q", org), err.Error())
 		return
 	}
+	idx := slices.IndexFunc(plugins, func(p *models.Plugin) bool {
+		return p.Install != nil && ptr.Value(p.Install.ID) == id
+	})
 	var install *models.Plugin
-	for _, p := range plugins {
-		if p.Install != nil && ptr.Value(p.Install.ID) == id {
-			install = p
-			break
-		}
+	if idx >= 0 {
+		install = plugins[idx]
 	}
 	if install == nil {
 		resp.State.RemoveResource(ctx)
@@ -315,9 +316,9 @@ func pluginInstallToModel(org string, install *models.PluginInstall, data *plugi
 	data.ID = types.Int64Value(int64(ptr.Value(install.ID)))
 	if install.UUID != nil {
 		data.UUID = types.StringValue(install.UUID.String())
-	} else {
-		data.UUID = types.StringValue("")
 	}
+	// nil UUID: preserve existing state value (API omits uuid in List response;
+	// overwriting with "" would cause persistent drift — mirrors ENG-183 / PR #109).
 	data.Status = types.StringPointerValue(install.Status)
 	data.CreatedAt = types.Int64Value(int64(ptr.Value(install.CreatedAt)))
 	data.UpdatedAt = types.Int64Value(int64(ptr.Value(install.UpdatedAt)))

--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -151,8 +151,48 @@ func (r *pluginResource) Read(ctx context.Context, req resource.ReadRequest, res
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *pluginResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
-	// All fields use RequiresReplace — Update is never called.
+func (r *pluginResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pluginResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// id is computed from state; read it separately so we don't lose it.
+	var state pluginResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, plan.Organization)
+	m := r.provider.Middleware
+
+	id := uint32(state.ID.ValueInt64())
+	versionID := uint32(plan.PluginVersionID.ValueInt64())
+
+	config, err := mergePluginConfiguration(ctx, plan)
+	if err != nil {
+		resp.Diagnostics.AddError("invalid plugin configuration", err.Error())
+		return
+	}
+
+	_, _, err = m.UpdatePlugin(org, id, versionID, config)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to update plugin install %d in org %q", id, org), err.Error())
+		return
+	}
+
+	install, err := pollPluginInstall(m, org, uint32(plan.RegistryID.ValueInt64()), uint32(plan.PluginID.ValueInt64()), versionID, 5*time.Minute)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("plugin update did not reach running status in org %q", org), err.Error())
+		return
+	}
+
+	plan.RegistryID = types.Int64Value(plan.RegistryID.ValueInt64())
+	plan.PluginID = types.Int64Value(plan.PluginID.ValueInt64())
+	pluginInstallToModel(org, install, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *pluginResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/plugin_resource_test.go
+++ b/provider/plugin_resource_test.go
@@ -71,6 +71,14 @@ func TestAccPluginResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("cycloid_plugin.test", "status"),
 				),
 			},
+			// ENG-189 regression: changing configuration must succeed with in-place
+			// update (no 409 "Plugin already exists" from a destroy+create cycle).
+			{
+				Config: testAccPluginConfig_updated(orgCanonical, int(registryID), int(pluginID), int(versionID)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_plugin.test", "status", "running"),
+				),
+			},
 			{
 				// configuration/configuration_sensitive cannot be recovered from the API —
 				// the API returns merged config with no way to split back. Ignored on import.
@@ -125,6 +133,25 @@ resource "cycloid_plugin" "test" {
   }
   configuration_sensitive = {
     token = "test-token"
+  }
+}
+`, org, registryID, pluginID, versionID)
+}
+
+// testAccPluginConfig_updated changes the configuration value to exercise the
+// in-place Update path (ENG-189 regression guard).
+func testAccPluginConfig_updated(org string, registryID, pluginID, versionID int) string {
+	return fmt.Sprintf(`
+resource "cycloid_plugin" "test" {
+  organization      = %q
+  registry_id       = %d
+  plugin_id         = %d
+  plugin_version_id = %d
+  configuration = {
+    greeting = "world"
+  }
+  configuration_sensitive = {
+    token = "updated-token"
   }
 }
 `, org, registryID, pluginID, versionID)

--- a/resource_plugin/plugin_schema.go
+++ b/resource_plugin/plugin_schema.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -14,9 +13,9 @@ import (
 func PluginResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Description: "Install a plugin in an organization. " +
-			"All fields trigger a replacement on change because plugin upgrades are not supported via the API yet.",
+			"Version and configuration can be updated in-place; registry, plugin ID, and organization require replacement.",
 		MarkdownDescription: "Install a plugin in an organization. " +
-			"All fields trigger a replacement on change because plugin upgrades are not supported via the API yet.",
+			"Version and configuration can be updated in-place; registry, plugin ID, and organization require replacement.",
 		Attributes: map[string]schema.Attribute{
 			"organization": schema.StringAttribute{
 				Description:         "The organization canonical, defaults to the provider `default_organization`.",
@@ -38,31 +37,28 @@ func PluginResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers:       []planmodifier.Int64{int64planmodifier.RequiresReplace()},
 			},
 			"plugin_version_id": schema.Int64Attribute{
-				Description:         "The ID of the plugin version to install. Triggers replacement when changed.",
-				MarkdownDescription: "The ID of the plugin version to install. Triggers replacement when changed.",
+				Description:         "The ID of the plugin version to install. Can be updated in-place.",
+				MarkdownDescription: "The ID of the plugin version to install. Can be updated in-place.",
 				Required:            true,
-				PlanModifiers:       []planmodifier.Int64{int64planmodifier.RequiresReplace()},
 			},
 			"configuration": schema.MapAttribute{
 				Description: "Visible key-value configuration for the plugin (Stack Forms syntax). " +
-					"Values appear in plan output. Triggers replacement when changed.",
+					"Values appear in plan output. Can be updated in-place.",
 				MarkdownDescription: "Visible key-value configuration for the plugin (Stack Forms syntax). " +
-					"Values appear in plan output. Triggers replacement when changed.",
-				Optional:      true,
-				ElementType:   types.StringType,
-				PlanModifiers: []planmodifier.Map{mapplanmodifier.RequiresReplace()},
+					"Values appear in plan output. Can be updated in-place.",
+				Optional:    true,
+				ElementType: types.StringType,
 			},
 			"configuration_sensitive": schema.MapAttribute{
 				Description: "Sensitive key-value configuration for the plugin (Stack Forms syntax). " +
-					"Values are hidden in plan output. Triggers replacement when changed. " +
+					"Values are hidden in plan output. Can be updated in-place. " +
 					"Keys must not overlap with `configuration`.",
 				MarkdownDescription: "Sensitive key-value configuration for the plugin (Stack Forms syntax). " +
-					"Values are hidden in plan output. Triggers replacement when changed. " +
+					"Values are hidden in plan output. Can be updated in-place. " +
 					"Keys must not overlap with `configuration`.",
-				Optional:      true,
-				Sensitive:     true,
-				ElementType:   types.StringType,
-				PlanModifiers: []planmodifier.Map{mapplanmodifier.RequiresReplace()},
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
 			},
 			"id": schema.Int64Attribute{
 				Description:         "The numeric ID of the installed plugin.",


### PR DESCRIPTION
## Summary

- **Root cause of 409 on update**: `Update()` was a no-op stub — it never called the API.
- **Root cause of 404 on every subsequent update**: `Read()` called `m.GetPlugin()`, which deserialises `models.Plugin` JSON into `*models.PluginInstall`. Because both types share a top-level `"id"` field, `Plugin.ID` (registry plugin ID) silently overwrote `state.id` (install ID) after every refresh. Every subsequent `Update`/`Delete` then 404'd against the wrong ID.
- **Additional**: `pluginInstallToModel` crashed on nil UUID (list response omits it); `compose.yml` needed `ORGS_CANS=cycloid` so the plugin-manager auto-registers with the local stack org.

### Changes

- `provider/plugin_resource.go`
  - Implement `Update()`: calls `m.UpdatePlugin(org, installID, versionID, config)` then polls for `"running"`
  - Fix `Read()` and `ImportState()`: replace `m.GetPlugin()` with `m.ListPlugins()` + search by install ID
  - Remove `RequiresReplace` from `plugin_version_id`, `configuration`, `configuration_sensitive` (were blocking in-place update)
  - Nil-UUID guard in `pluginInstallToModel`
- `compose.yml`: add `ORGS_CANS=cycloid` to plugin-manager environment

## Test plan

- [x] `TestAccPluginResource` — all 3 steps (Create → Update config → ImportState) GREEN locally against local stack
- [ ] CI acceptance suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)