### PR TITLE
backport(v0.6, TFPRO-45): fix team='' inconsistent result after apply

### DIFF
--- a/provider/stack_resource.go
+++ b/provider/stack_resource.go
@@ -90,8 +90,8 @@ func (s *stackResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	if stack.Team == nil {
-		data.Team = types.StringNull()
+	if stack.Team == nil || ptr.Value(stack.Team.Canonical) == "" {
+		data.Team = types.StringValue("")
 	} else {
 		data.Team = types.StringValue(ptr.Value(stack.Team.Canonical))
 	}
@@ -169,7 +169,7 @@ func (s *stackResource) UpdateStack(org string, stack *models.ServiceCatalog, da
 	}
 
 	if updatedStack.Team == nil || ptr.Value(updatedStack.Team.Canonical) == "" {
-		data.Team = types.StringNull()
+		data.Team = types.StringValue("")
 	} else {
 		data.Team = types.StringValue(ptr.Value(updatedStack.Team.Canonical))
 	}

--- a/provider/stack_resource_test.go
+++ b/provider/stack_resource_test.go
@@ -43,6 +43,56 @@ func TestAccStackResource(t *testing.T) {
 	})
 }
 
+// TestAccStackResource_TeamEmpty is a regression test for TFPRO-45:
+// applying a cycloid_stack with team="" must not produce
+// "Provider produced inconsistent result after apply" (.team was "" but now null).
+func TestAccStackResource_TeamEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgCanonical := testAccGetOrganizationCanonical()
+	depManager := NewTestDependencyManager(t)
+	defer depManager.Cleanup(ctx, t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			// Apply with explicit team=""; must not error with inconsistent-result.
+			{
+				Config: testAccStackConfig_teamEmpty(orgCanonical),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_stack.test_team", "team", ""),
+				),
+			},
+			// Second plan must be clean (no perpetual diff).
+			{
+				Config:   testAccStackConfig_teamEmpty(orgCanonical),
+				PlanOnly: true,
+			},
+			{
+				Config:  " ",
+				Destroy: true,
+			},
+		},
+	})
+}
+
+func testAccStackConfig_teamEmpty(org string) string {
+	return fmt.Sprintf(`
+data "cycloid_stacks" "existing_team" {
+  organization_canonical = %q
+}
+
+resource "cycloid_stack" "test_team" {
+  organization_canonical = %q
+  canonical              = data.cycloid_stacks.existing_team.stacks[0].canonical
+  visibility             = "local"
+  team                   = ""
+}
+`, org, org)
+}
+
 func testAccStackConfig_basic(org string) string {
 	return fmt.Sprintf(`
 data "cycloid_stacks" "existing" {


### PR DESCRIPTION
Backport of #112 to `release/v0.6`.

Cherry-picks:
- `7e4603f` fix(stack): normalize team="" to avoid inconsistent-result after apply (TFPRO-45)

See #112 for full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)