### PR TITLE
fix: restore RequiresReplace on plugin_version_id

### DIFF
--- a/docs/resources/plugin.md
+++ b/docs/resources/plugin.md
@@ -156,7 +156,7 @@ resource "cycloid_plugin" "hello" {
 ### Required
 
 - `plugin_id` (Number) The ID of the plugin within the registry.
-- `plugin_version_id` (Number) The ID of the plugin version to install. Can be updated in-place.
+- `plugin_version_id` (Number) The ID of the plugin version to install. Changing this triggers replacement.
 - `registry_id` (Number) The ID of the plugin registry containing the plugin to install.
 
 ### Optional

--- a/resource_plugin/plugin_schema.go
+++ b/resource_plugin/plugin_schema.go
@@ -13,9 +13,9 @@ import (
 func PluginResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Description: "Install a plugin in an organization. " +
-			"Version and configuration can be updated in-place; registry, plugin ID, and organization require replacement.",
+			"Configuration can be updated in-place; version, registry, plugin ID, and organization require replacement.",
 		MarkdownDescription: "Install a plugin in an organization. " +
-			"Version and configuration can be updated in-place; registry, plugin ID, and organization require replacement.",
+			"Configuration can be updated in-place; version, registry, plugin ID, and organization require replacement.",
 		Attributes: map[string]schema.Attribute{
 			"organization": schema.StringAttribute{
 				Description:         "The organization canonical, defaults to the provider `default_organization`.",
@@ -37,9 +37,10 @@ func PluginResourceSchema(ctx context.Context) schema.Schema {
 				PlanModifiers:       []planmodifier.Int64{int64planmodifier.RequiresReplace()},
 			},
 			"plugin_version_id": schema.Int64Attribute{
-				Description:         "The ID of the plugin version to install. Can be updated in-place.",
-				MarkdownDescription: "The ID of the plugin version to install. Can be updated in-place.",
+				Description:         "The ID of the plugin version to install. Changing this triggers replacement.",
+				MarkdownDescription: "The ID of the plugin version to install. Changing this triggers replacement.",
 				Required:            true,
+				PlanModifiers:       []planmodifier.Int64{int64planmodifier.RequiresReplace()},
 			},
 			"configuration": schema.MapAttribute{
 				Description: "Visible key-value configuration for the plugin (Stack Forms syntax). " +


### PR DESCRIPTION
## Summary

- Restores `RequiresReplace` on `plugin_version_id` — the API rejects version changes in `UpdatePluginInstall` (youdeploy-http-api PR #5944), so Terraform must do destroy+create when the version changes
- Configuration updates remain in-place (the ENG-189 fix)

## Context

PR #111 removed `RequiresReplace` from `plugin_version_id`, but the API now validates that version changes are not supported and returns an error. Without `RequiresReplace`, users changing the version would get a confusing API error instead of a clean destroy+create cycle.

## Test plan

- [x] Schema-only change, no logic affected
- [ ] CI acceptance suite