### PR TITLE
fix(environment): delete org-level environment on resource destroy

### DIFF
--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -151,9 +151,18 @@ func (p *environmentResource) Delete(ctx context.Context, req resource.DeleteReq
 	project := data.Project.ValueString()
 	canonical := data.Canonical.ValueString()
 
+	// The cycloid_environment resource owns the org-level environment, so deleting it
+	// must remove the environment itself, not only unlink it from the project. The
+	// unlink has to come first: the org-level delete is rejected while the environment
+	// is still attached to a project.
 	_, err := m.UnlinkEnvFromProject(org, project, canonical, middleware.DeleteOptions{})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to unlink environment from project while deleting resource", err.Error())
+		return
+	}
+
+	if _, err := m.DeleteOrgEnv(org, canonical); err != nil {
+		resp.Diagnostics.AddError("failed to delete environment while deleting resource", err.Error())
 		return
 	}
 

--- a/provider/environment_resource_test.go
+++ b/provider/environment_resource_test.go
@@ -2,11 +2,15 @@ package provider
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"testing"
 
+	middleware "github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/terraform-provider-cycloid/internal/ptr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // TestAccEnvironmentResource provisions the project via dependencies (EnsureTestProject) and only
@@ -33,6 +37,27 @@ func TestAccEnvironmentResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
 		PreCheck:                 func() { testAccPreCheck(t) },
+		// Destroying the resource must delete the org-level environment, not just
+		// unlink it from the project, otherwise the environment lingers and blocks
+		// its environment type from being deleted (ENGBE-279).
+		CheckDestroy: func(s *terraform.State) error {
+			m := depManager.GetProvider().Middleware
+			for _, rs := range s.RootModule().Resources {
+				if rs.Type != "cycloid_environment" {
+					continue
+				}
+				canonical := rs.Primary.Attributes["canonical"]
+				_, _, err := m.GetOrgEnv(orgCanonical, canonical)
+				if err == nil {
+					return fmt.Errorf("environment %q still exists after destroy", canonical)
+				}
+				var apiErr *middleware.APIResponseError
+				if !stderrors.As(err, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+					return fmt.Errorf("unexpected error checking environment %q after destroy: %w", canonical, err)
+				}
+			}
+			return nil
+		},
 		Steps: []resource.TestStep{
 			// Create environment with existing project dependency
 			{


### PR DESCRIPTION
## Context

[ENGBE-279](https://linear.app/cycloid/issue/ENGBE-279) — after `terraform destroy`, Environment Types can't be deleted:
> API error 409: The Environment Type is still in use by one or more Environment with canonicals: prod

## Root cause

The `cycloid_environment` resource owns the org-level environment: on **create** it calls `CreateOrgEnv` **and** `LinkEnvToProject`. But on **delete** it only called `UnlinkEnvFromProject` — it never deleted the environment. So `terraform destroy` left the org-level environment behind, still referencing its environment type, which blocks the type's deletion (and leaves it lingering in Org Settings).

This is the provider-side counterpart of the governance refactor in `youdeploy-http-api`, where unlinking an environment intentionally no longer deletes it (environments are first-class org-level entities whose env vars / provider settings can be reused). The API behaviour is correct; the provider just wasn't completing the teardown.

## Change

`cycloid_environment` Delete now:
1. `UnlinkEnvFromProject` (must stay first — the org-level delete is rejected while the env is still attached to a project), then
2. `DeleteOrgEnv` to remove the org-level environment.

`cycloid_environment_link` is **unchanged** and remains link-only, so environments managed purely via links still persist by design.

## Testing

- `go build ./...` and `go vet ./provider/` pass.
- Added a `CheckDestroy` to `TestAccEnvironmentResource` asserting `GetOrgEnv` returns 404 after destroy — the assertion that would have caught this. Requires a live backend (`CY_API_URL` / `CY_API_KEY` / `CY_ORG`); skips cleanly without them. Needs an acceptance run in CI to validate end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)