### PR TITLE
fix(provider): remove state instead of hard-erroring on out-of-band delete (TFPRO-50)

### DIFF
--- a/provider/component_resource.go
+++ b/provider/component_resource.go
@@ -94,13 +94,7 @@ func (r *ComponentResource) Read(ctx context.Context, req resource.ReadRequest, 
 		}
 	}
 	if component == nil {
-		resp.Diagnostics.Append(
-			ComponentToModel(ctx, org, nil, nil, nil, &componentState, false)...,
-		)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		resp.Diagnostics.Append(resp.State.Set(ctx, &componentState)...)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/provider/environment_resource.go
+++ b/provider/environment_resource.go
@@ -82,11 +82,7 @@ func (p *environmentResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	if !found {
-		resp.Diagnostics.Append(environmentToValue(ctx, org, project, &models.Environment{}, &data)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/provider/not_found.go
+++ b/provider/not_found.go
@@ -12,10 +12,15 @@ func isNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// A typed 404 is an unambiguous not-found signal.
 	var apiErr *cycloidmiddleware.APIResponseError
-	if errors.As(err, &apiErr) {
-		return apiErr.StatusCode == http.StatusNotFound
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+		return true
 	}
+	// Some backends (e.g. plugin-manager) report a missing object as a 422
+	// validation error with a "was not found" message instead of a 404. Fall
+	// back to matching the message so those still resolve to state removal
+	// instead of a hard error.
 	errMessage := strings.ToLower(err.Error())
 	return strings.Contains(errMessage, " not found") ||
 		strings.Contains(errMessage, "notfound") ||

--- a/provider/not_found_test.go
+++ b/provider/not_found_test.go
@@ -46,6 +46,26 @@ func TestIsNotFoundError(t *testing.T) {
 			expected: false,
 		},
 		{
+			// Regression for TFPRO-50: plugin-manager reports a deleted
+			// object as a 422 with a "was not found" message rather than a
+			// 404. isNotFoundError must not let the typed-error branch
+			// short-circuit past the message-based fallback in this case.
+			name: "*APIResponseError 422 plugin manager not found",
+			err: &cycloidmiddleware.APIResponseError{
+				StatusCode: http.StatusUnprocessableEntity,
+				Status:     "The Plugin Manager is invalid: The Plugin Manager was not found",
+			},
+			expected: true,
+		},
+		{
+			name: "*APIResponseError 422 unrelated validation error",
+			err: &cycloidmiddleware.APIResponseError{
+				StatusCode: http.StatusUnprocessableEntity,
+				Status:     "The Plugin Manager is invalid: Name cannot be blank",
+			},
+			expected: false,
+		},
+		{
 			name:     "non not found error",
 			err:      errors.New("A 500 error was returned on \"getConfigRepository\" call"),
 			expected: false,

--- a/provider/plugin_manager_resource_test.go
+++ b/provider/plugin_manager_resource_test.go
@@ -105,6 +105,57 @@ func TestAccPluginManagerResource_Create(t *testing.T) {
 	})
 }
 
+// TestAccPluginManagerResource_RecreateAfterOutOfBandDelete reproduces TFPRO-50:
+// a plugin manager removed outside terraform must be detected during Read and
+// removed from state (RemoveResource), so the next apply recreates it cleanly
+// instead of hard-erroring on the backend's 422 "was not found" response.
+func TestAccPluginManagerResource_RecreateAfterOutOfBandDelete(t *testing.T) {
+	orgCanonical := testAccGetOrganizationCanonical()
+	depManager := NewTestDependencyManager(t)
+	m := depManager.GetProvider().Middleware
+
+	if m == nil {
+		t.Skip("skipping acceptance test: middleware not configured")
+	}
+
+	deleteAllPluginManagers(t, m, orgCanonical)
+	t.Cleanup(func() {
+		restoreClusterPluginManager(t, m, orgCanonical)
+	})
+
+	config := testAccPluginManagerConfig(orgCanonical, clusterTestPluginManager, clusterPluginManagerURL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("cycloid_plugin_manager.test", "id"),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Simulate the customer scenario: the plugin manager is
+					// removed out-of-band, i.e. outside terraform.
+					deleteAllPluginManagers(t, m, orgCanonical)
+				},
+				Config: config,
+				// A clean recreate: no 422 error, the resource comes back
+				// with the same config, and (via the framework's built-in
+				// post-apply plan check) a follow-up plan is empty.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("cycloid_plugin_manager.test", "id"),
+					resource.TestCheckResourceAttr("cycloid_plugin_manager.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_plugin_manager.test", "name", clusterTestPluginManager),
+					testAccCheckPluginManagerInviteAccepted(orgCanonical, m),
+				),
+			},
+		},
+	})
+}
+
 func findAcceptedPluginManager(managers []*models.PluginManager) *models.PluginManager {
 	for _, mgr := range managers {
 		if mgr.InviteStatus == nil {

--- a/provider/project_resource.go
+++ b/provider/project_resource.go
@@ -71,19 +71,17 @@ func (p *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if i := slices.IndexFunc(projects, func(p *models.Project) bool {
+	i := slices.IndexFunc(projects, func(p *models.Project) bool {
 		return ptr.Value(p.Canonical) == canonical
-	}); i == -1 {
-		// Project doesn't exist, so empty state
-		resp.Diagnostics.Append(projectToValue(ctx, org, &models.Project{}, &data)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	} else {
-		resp.Diagnostics.Append(projectToValue(ctx, org, projects[i], &data)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	})
+	if i == -1 {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(projectToValue(ctx, org, projects[i], &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/provider/stack_resource.go
+++ b/provider/stack_resource.go
@@ -86,6 +86,10 @@ func (s *stackResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	stackRef := fmt.Sprintf("%s:%s", orgCan, data.Canonical.ValueString())
 	stack, _, err := mid.GetStack(orgCan, stackRef)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to get stack informations with ref '%s'.", stackRef), err.Error())
 		return
 	}

--- a/provider/team_resource.go
+++ b/provider/team_resource.go
@@ -85,6 +85,11 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		}
 	}
 
+	if team == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	resp.Diagnostics.Append(
 		TeamToModel(ctx, org, team, &teamState)...,
 	)


### PR DESCRIPTION
## Bug

Customer removed a plugin manager manually (outside terraform). Re-running the stack then hard-errored instead of re-creating it:

```
Error: failed to read plugin manager 17 in org "..."
API error 422: The Plugin Manager is invalid: The Plugin Manager was not found
```

## Root cause

`isNotFoundError()` (`provider/not_found.go`) matched a typed `*APIResponseError` and returned `apiErr.StatusCode == http.StatusNotFound` **immediately**, skipping the message-based fallback entirely whenever the typed error didn't happen to carry a literal 404. The plugin-manager backend reports a deleted object as a **422** with a `"... was not found"` message, not a 404 — so the typed branch matched, returned `false`, and `Read()` fell through to a hard `AddError` instead of `RemoveResource`.

Fix: only short-circuit `true` for a literal 404; for anything else, fall through to the existing message-based heuristic regardless of whether the error was typed. This is a narrow, additive change — it only flips prior false negatives to `true`; no existing `true` result changes (see new unit test cases: the 422 plugin-manager message now returns `true`, an unrelated 422 validation error still returns `false`).

## Audit — same not-found class of bug across every resource Read()

Per the issue's ask, audited every `provider/*_resource.go` `Read()` for not-found handling:

| Resource(s) | Pattern | Status |
|---|---|---|
| plugin_manager, catalog_repository, cloud_account, credential, external_backend, plugin_registry, organization, organization_member, plugin_registry_plugin, plugin_resource, config_repository, oidc_organization_settings, environment_type, oidc_integration, oidc_group_mapping, organization_role, organization_environment, plugin_version, team_member, environment_link | `isNotFoundError()` → `RemoveResource` | OK — inherits the `not_found.go` fix, no per-file change needed |
| `stack_resource.go` | `GetStack` err → always hard `AddError`, zero not-found handling | **Fixed** — added `isNotFoundError` check → `RemoveResource` |
| `team_resource.go` | list+find; not-found → nulls all fields + `State.Set` (never removes) | **Fixed** — not-found → `RemoveResource` |
| `project_resource.go` | list+index; not-found → nulls all fields + `State.Set` | **Fixed** — not-found → `RemoveResource` |
| `environment_resource.go` | list+found bool; not-found → nulls all fields + `State.Set` | **Fixed** — not-found → `RemoveResource` |
| `component_resource.go` | list+find; `component == nil` → nulls all fields + `State.Set` (the separate config-not-found branch via `isComponentNotFoundError` is a distinct, legitimate case — untouched) | **Fixed** — `component == nil` → `RemoveResource` |

## Tests

- New unit test cases in `not_found_test.go` reproduce the exact 422 message from the bug report (verified they fail against the pre-fix code and pass after).
- New acceptance test `TestAccPluginManagerResource_RecreateAfterOutOfBandDelete`: creates the plugin manager, deletes it out-of-band via the middleware client, then re-applies — asserts no 422 error and a clean recreate (the framework's built-in post-apply plan check also asserts no perpetual diff).
- Ran locally against the docker-compose backend (`just be-reset`, `TF_ACC=1 go test ./provider/...`): all touched-resource acceptance tests green (team, project, environment, component ×5, stack ×2, plugin_manager ×3).
- `go build`, `go vet`, `golangci-lint run` all clean.

## Notes

- Repo default branch is `master` (no `develop`) — branched/PR'd against `master`.
- Not merging — stopping at green PR per fleet-worker brief.

🤖 Generated with a fleet worker session — https://claude.ai/code/session_014CST9mw3ABSA4aYHNy96EV