### PR TITLE
fix(provider): preserve wait_until_connected through Update (TFPRO-51)

### DIFF
--- a/provider/plugin_registry_resource.go
+++ b/provider/plugin_registry_resource.go
@@ -125,8 +125,52 @@ func (r *pluginRegistryResource) Read(ctx context.Context, req resource.ReadRequ
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *pluginRegistryResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
-	// All fields use RequiresReplace — Update is never called.
+// Update is reached whenever wait_until_connected changes — it's the only
+// attribute without a RequiresReplace plan modifier. It must call
+// resp.State.Set with the plan's WaitUntilConnected value preserved (the API
+// doesn't return this client-side flag, so pluginRegistryToModel never
+// touches it); leaving it unset here is what caused TFPRO-51's "produced
+// inconsistent result after apply" on wait_until_connected.
+func (r *pluginRegistryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data pluginRegistryResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	org := getOrganizationCanonical(*r.provider, data.Organization)
+	m := r.provider.Middleware
+	id := uint32(data.ID.ValueInt64())
+
+	if data.WaitUntilConnected.ValueBool() {
+		if err := pollPluginRegistryConnected(m, org, id, 5*time.Minute); err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("plugin registry %d did not reach connected status in org %q", id, org),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	registries, _, err := m.ListPluginRegistries(org)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to list plugin registries in org %q", org), err.Error())
+		return
+	}
+	var registry *models.PluginRegistry
+	for _, reg := range registries {
+		if reg.ID != nil && uint32(*reg.ID) == id {
+			registry = reg
+			break
+		}
+	}
+	if registry == nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("failed to update plugin registry %d in org %q", id, org), "registry not found")
+		return
+	}
+
+	pluginRegistryToModel(org, registry, &data)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *pluginRegistryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/plugin_registry_resource_test.go
+++ b/provider/plugin_registry_resource_test.go
@@ -47,12 +47,82 @@ func TestAccPluginRegistryResource(t *testing.T) {
 	})
 }
 
+// TestAccPluginRegistryResource_WaitUntilConnected reproduces TFPRO-51: enabling
+// wait_until_connected (a client-side, config-only flag not returned by the API)
+// must not cause "Provider produced inconsistent result after apply".
+func TestAccPluginRegistryResource_WaitUntilConnected(t *testing.T) {
+	registryName := RandomCanonical("test-registry")
+	orgCanonical := testAccGetOrganizationCanonical()
+	depManager := NewTestDependencyManager(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPluginRegistryWaitConfig(orgCanonical, registryName, clusterPluginRegistryURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_plugin_registry.test", "organization", orgCanonical),
+					resource.TestCheckResourceAttr("cycloid_plugin_registry.test", "name", registryName),
+					resource.TestCheckResourceAttr("cycloid_plugin_registry.test", "wait_until_connected", "true"),
+					resource.TestCheckResourceAttrSet("cycloid_plugin_registry.test", "id"),
+				),
+			},
+			{
+				// A second plan with the same config must be clean — no
+				// perpetual diff on wait_until_connected.
+				Config:   testAccPluginRegistryWaitConfig(orgCanonical, registryName, clusterPluginRegistryURL),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccPluginRegistryResource_WaitUntilConnectedUpdate reproduces TFPRO-51 via
+// an in-place update: wait_until_connected has no RequiresReplace plan
+// modifier, so flipping it triggers Update(), which is currently a no-op stub.
+func TestAccPluginRegistryResource_WaitUntilConnectedUpdate(t *testing.T) {
+	registryName := RandomCanonical("test-registry")
+	orgCanonical := testAccGetOrganizationCanonical()
+	depManager := NewTestDependencyManager(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: depManager.GetProviderFactories(),
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPluginRegistryConfig(orgCanonical, registryName, clusterPluginRegistryURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("cycloid_plugin_registry.test", "id"),
+				),
+			},
+			{
+				Config: testAccPluginRegistryWaitConfig(orgCanonical, registryName, clusterPluginRegistryURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cycloid_plugin_registry.test", "wait_until_connected", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPluginRegistryConfig(org, name, url string) string {
 	return fmt.Sprintf(`
 resource "cycloid_plugin_registry" "test" {
   organization = %q
   name         = %q
   url          = %q
+}
+`, org, name, url)
+}
+
+func testAccPluginRegistryWaitConfig(org, name, url string) string {
+	return fmt.Sprintf(`
+resource "cycloid_plugin_registry" "test" {
+  organization          = %q
+  name                  = %q
+  url                   = %q
+  wait_until_connected  = true
 }
 `, org, name, url)
 }


### PR DESCRIPTION
Supersedes #129, which GitHub auto-closed when #128 (TFPRO-50) was squash-merged and its branch deleted — the old PR's base branch no longer existed, and GitHub couldn't retarget it (squash merge means the original commits aren't reachable from `master`), so it closed instead. Same branch, rebased cleanly onto the new `master` tip (no conflicts), content unchanged.

## Bug

After enabling `wait_until_connected` on `cycloid_plugin_registry`:

```
Error: Provider produced inconsistent result after apply
  ...cycloid_plugin_registry.registry["local"],
  produced an unexpected new value: .wait_until_connected: was cty.True, but now null.
```

## Root cause

`wait_until_connected` has no `RequiresReplace` plan modifier (unlike `organization`/`name`/`url`), so toggling it in config routes through `Update()` — which was a no-op stub:

```go
func (r *pluginRegistryResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
	// All fields use RequiresReplace — Update is never called.
}
```

That comment is wrong for this resource: `wait_until_connected` is the one attribute that *isn't* `RequiresReplace`, so `Update()` is reachable. Since it never calls `resp.State.Set`, the final state came back entirely unset, and Terraform flagged that against the still-`true` planned value.

I verified this empirically before assuming it — a plain create-then-`PlanOnly` cycle with `wait_until_connected = true` does **not** reproduce the error (Create/Read both correctly preserve it via `req.Plan.Get`/`req.State.Get` since `pluginRegistryToModel` never touches that field). It only reproduces on an in-place **update** that changes `wait_until_connected`, because that's the one path that hits the no-op `Update()`.

## Fix

Implement `Update()` the same way `Create()` already does: read the plan, optionally poll for `connected`, refresh from the API via `ListPluginRegistries`, then `pluginRegistryToModel` + `resp.State.Set`. `pluginRegistryToModel` never touches `WaitUntilConnected` (the API doesn't return this client-side flag), so it naturally carries over from the plan — same pattern Create already relies on.

## Tests

- `TestAccPluginRegistryResource_WaitUntilConnected`: create with `wait_until_connected = true`, then a `PlanOnly` step asserts no perpetual diff.
- `TestAccPluginRegistryResource_WaitUntilConnectedUpdate`: create without it, then update to `wait_until_connected = true` — this is the step that actually reproduces the bug. Confirmed failing against the pre-fix code with the exact `"was cty.True, but now null"` message; passes after the fix.
- Full local acceptance suite against the docker-compose backend: 90 passed, 1 pre-existing unrelated flake (`TestAccPluginManagerResource`, a long-lived-backend ID-drift issue, already documented on #128), 1 pre-existing skip.
- `go build`, `go vet`, `golangci-lint run` clean.

## Audit — other config-only attributes not round-tripped by the API

- **`plugin_manager_resource.go` has the identical latent bug** (same missing `RequiresReplace`, same no-op `Update()`). Not fixed here — out of TFPRO-51's scope, flagged for a follow-up ticket.
- Everywhere else `Update()` claims "never called," verified every non-`Computed` attribute genuinely does carry `RequiresReplace` (`environment_link_resource.go`, `oidc_group_mapping_resource.go`, `plugin_version_resource.go`) — accurate, no bug there.
- `plugin_resource.go`'s `configuration`/`configuration_sensitive` are a similar-looking case but already handled correctly (preserved from state in Read) — not a bug.

🤖 Generated with a fleet worker session — https://claude.ai/code/session_014CST9mw3ABSA4aYHNy96EV