### PR TITLE
ci: add commitlint + PR-lint for Linear-key discipline (OPS-1541)

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,48 @@
+name: PR Lint
+
+# Commit convention gate feeding Linear releases (changie retirement).
+# Validates PR commits AND the PR title (the PR title becomes the commit once we
+# squash-merge). Conventional Commits + a Linear issue key on release-note types
+# (see commitlint.config.js). No secrets, no self-hosted runner needed — runs on
+# GitHub-hosted ubuntu-latest (free for this trust-safe lint).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-lint-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Commit convention
+    runs-on: ubuntu-latest
+    # Same-repo PRs only; skip dependency bots (they carry no Linear key and are
+    # exempt "Maintenance" changes). Fork PRs are skipped here (contributors have no
+    # Linear access); a maintainer re-runs from an internal branch if needed.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint PR commits
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.mjs
+
+      - name: Lint PR title (becomes the squash commit)
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s\n' "$PR_TITLE" | npx --yes \
+            -p @commitlint/cli -p @commitlint/config-conventional \
+            commitlint --config commitlint.config.mjs

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,37 @@
+// Cycloid commit convention — feeds Linear releases (changie is being retired).
+//
+// Conventional Commits + a Linear issue key on release-note-bearing commits.
+// Release-note types (feat/fix/perf) MUST reference a Linear issue key (e.g. BE-123)
+// in the subject or body, so the release pipeline can link the issue to the Linear
+// release. Maintenance types (chore/build/ci/docs/style/test/refactor/revert) are
+// exempt — they land in the "Maintenance" bucket and need no key.
+//
+// ESM (.mjs) is required by wagoid/commitlint-github-action@v6.
+// NOTE: intended to be extracted into a shared @cycloid/commitlint-config package
+// once the monorepo lands; kept inline per-repo for now.
+
+const RELEASE_NOTE_TYPES = ['feat', 'fix', 'perf'];
+const LINEAR_KEY = /\b[A-Z]{2,}-\d+\b/;
+
+export default {
+  extends: ['@commitlint/config-conventional'],
+  plugins: [
+    {
+      rules: {
+        'linear-key-on-release-types': (parsed) => {
+          const { type, header, body } = parsed;
+          if (!type || !RELEASE_NOTE_TYPES.includes(type)) return [true];
+          const hasKey = LINEAR_KEY.test(`${header || ''}\n${body || ''}`);
+          return [
+            hasKey,
+            `a "${type}" commit must reference a Linear issue key (e.g. BE-123) ` +
+              `in the subject or body so it can be linked to the Linear release`,
+          ];
+        },
+      },
+    },
+  ],
+  rules: {
+    'linear-key-on-release-types': [2, 'always'],
+  },
+};


### PR DESCRIPTION
## What

Adds the commitlint + PR-lint gate (Conventional Commits + a Linear issue key on release-note types feat/fix/perf; maintenance types exempt; skips dependabot/renovate + fork PRs; ubuntu-latest, no secrets). Same gate as youdeploy-http-api#5981, youdeploy-frontend-web#8816, cycloid-cli#473.

## Why

Commit discipline feeding **Linear releases** as Changie is retired (OPS-1541). TFPRO releases via goreleaser go through the Linear "Public Release" pipeline too, and TFPRO folds into the backend monorepo — so it gets the same gate for uniformity.

## Notes

- Not blocking by default (make it a required check via branch protection when ready).
- Runs alongside the existing ci.yml/release.yml, no overlap.

Part of OPS-1541. 🤖 Generated with [Claude Code](https://claude.com/claude-code)