### PR TITLE
fix(credential): force replacement when canonical changes

### DIFF
--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -44,7 +44,7 @@ terraform {
 ### Optional
 
 - `body` (Attributes, Sensitive) The credential values, use the fields related to the credential `type`. (see [below for nested schema](#nestedatt--body))
-- `canonical` (String) The canonical of the credential.
+- `canonical` (String) The canonical of the credential. Changing the canonical forces a replacement.
 - `description` (String) The description of the credential.
 - `organization_canonical` (String) A canonical of an organization.
 - `owner` (String) User canonical that owns this credential. If omitted then the person creating this

--- a/provider/credential_canonical_replace_test.go
+++ b/provider/credential_canonical_replace_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCredentialSchemaCanonicalForcesReplaceWhenConfigured guards the fix for
+// the "Provider produced inconsistent result after apply" bug on `.canonical`.
+// The Cycloid API cannot cleanly rename a credential canonical (a PUT that
+// changes it renames server-side but responds 404), so a changed,
+// explicitly-configured canonical must force replacement rather than an
+// in-place update. This is enforced by a RequiresReplaceIfConfigured plan
+// modifier added in credentialResource.Schema(); the credential schema is
+// code-generated, so this also protects the post-processing from being lost on
+// regeneration.
+func TestCredentialSchemaCanonicalForcesReplaceWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	resp := &fwresource.SchemaResponse{}
+	NewCredentialResource().Schema(ctx, fwresource.SchemaRequest{}, resp)
+
+	attr, ok := resp.Schema.Attributes["canonical"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("canonical attribute is not a schema.StringAttribute: %T", resp.Schema.Attributes["canonical"])
+	}
+
+	found := false
+	for _, pm := range attr.PlanModifiers {
+		if strings.Contains(pm.Description(ctx), "destroy and recreate") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "canonical must force replacement when a configured value changes; the API cannot rename a credential canonical in place")
+}

--- a/provider/credential_resource.go
+++ b/provider/credential_resource.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -37,6 +39,25 @@ func (r *credentialResource) Metadata(ctx context.Context, req resource.Metadata
 
 func (r *credentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = resource_credential.CredentialResourceSchema(ctx)
+
+	// A credential's canonical is its immutable identity. The Cycloid API cannot
+	// cleanly rename it: a PUT that changes the canonical renames the credential
+	// server-side but responds 404. Without forcing replacement, changing an
+	// explicitly-configured canonical is planned as an in-place update that keeps
+	// the old canonical (see credentialCanonicalForUpdate) and writes it back,
+	// producing "Provider produced inconsistent result after apply" on
+	// `.canonical`. Force replacement instead, mirroring the cloud_account
+	// resource. The schema is code-generated, so this must be applied here rather
+	// than in the generated file. RequiresReplaceIfConfigured only triggers when
+	// canonical is set explicitly, leaving an omitted (API-derived) canonical
+	// unaffected.
+	if canonical, ok := resp.Schema.Attributes["canonical"].(schema.StringAttribute); ok {
+		canonical.PlanModifiers = append(canonical.PlanModifiers, stringplanmodifier.RequiresReplaceIfConfigured())
+		const replaceNote = " Changing the canonical forces a replacement."
+		canonical.Description += replaceNote
+		canonical.MarkdownDescription += replaceNote
+		resp.Schema.Attributes["canonical"] = canonical
+	}
 }
 
 func (r *credentialResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
Changing an explicitly-set `canonical` produced *"Provider produced inconsistent result after apply"* on `.canonical`.

**Cause:** on update, `credentialCanonicalForUpdate = Coalesce(state, plan)` preferred the old state canonical, updated the existing credential keeping it, and wrote it back — mismatching the planned new value.

**Fix:** a credential's canonical is immutable (the API can't rename it — a PUT that changes it renames server-side but responds 404), so changing an explicitly-configured canonical now forces replacement via `RequiresReplaceIfConfigured`, mirroring `cloud_account`. Omitted (API-derived) canonicals are unaffected.

**Tests:** schema unit guard + acceptance test that reproduces the bug (plan-check expects a replace). Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
